### PR TITLE
added clangd server

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ end
 ## Available LSPs
 
 - bashls
+- clangd
 - cssls
 - dockerls
 - eslintls

--- a/lua/nvim-lsp-installer/server.lua
+++ b/lua/nvim-lsp-installer/server.lua
@@ -3,6 +3,7 @@ local M = {}
 -- :'<,'>!sort
 local _SERVERS = {
     'bashls',
+    'clangd',
     'cssls',
     'dockerls',
     'eslintls',

--- a/lua/nvim-lsp-installer/servers/clangd.lua
+++ b/lua/nvim-lsp-installer/servers/clangd.lua
@@ -3,8 +3,6 @@ local server = require('nvim-lsp-installer.server')
 local root_dir = server.get_server_root_path('c-family')
 
 local install_cmd = [=[
-rm -r clangd;
-
 if [[ $(uname) == Linux ]]; then
   wget -O clangd.zip https://github.com/clangd/clangd/releases/download/11.0.0/clangd-linux-11.0.0.zip;
 elif [[ $(uname) == Darwin ]]; then 

--- a/lua/nvim-lsp-installer/servers/clangd.lua
+++ b/lua/nvim-lsp-installer/servers/clangd.lua
@@ -1,0 +1,30 @@
+local server = require('nvim-lsp-installer.server')
+
+local root_dir = server.get_server_root_path('c-family')
+
+local install_cmd = [=[
+rm -r clangd;
+
+if [[ $(uname) == Linux ]]; then
+  wget -O clangd.zip https://github.com/clangd/clangd/releases/download/11.0.0/clangd-linux-11.0.0.zip;
+elif [[ $(uname) == Darwin ]]; then 
+  wget -O clangd.zip https://github.com/clangd/clangd/releases/download/11.0.0/clangd-mac-11.0.0.zip; 
+else 
+  >&2 echo "$(uname) not supported."; 
+  exit 1;
+fi
+
+unzip clangd.zip; 
+rm clangd.zip;
+mv clangd_11.0.0 clangd;
+
+]=]
+
+return server.Server:new {
+  name = "clangd",
+  root_dir = root_dir, 
+  install_cmd = install_cmd, 
+  default_options = {
+    cmd = { root_dir .. '/clangd/bin/clangd'},
+  }
+}


### PR DESCRIPTION
This adds a basic clangd-11.0.0 server configuration for c, cpp and obj-c source files. 
I reckon there's some inner configuration that takes place thanks to `nvim-lspconfig` itself, as stated in the [documentation](https://github.com/neovim/nvim-lspconfig/blob/master/CONFIG.md#clangd). 

Tested on Linux 5.11.10-arch1-1, but it should work fine for macOS as well. 
If I got anything wrong, I'm happy to fix it!