### PR TITLE
added gopls server

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ end
 - cssls
 - dockerls
 - eslintls
+- gopls
 - graphql
 - html
 - jsonls

--- a/lua/nvim-lsp-installer/server.lua
+++ b/lua/nvim-lsp-installer/server.lua
@@ -7,6 +7,7 @@ local _SERVERS = {
     'cssls',
     'dockerls',
     'eslintls',
+    'gopls',
     'graphql',
     'html',
     'jsonls',

--- a/lua/nvim-lsp-installer/servers/gopls.lua
+++ b/lua/nvim-lsp-installer/servers/gopls.lua
@@ -5,7 +5,7 @@ local root_dir = server.get_server_root_path('go')
 local install_cmd = [=[
 
 GO111MODULE=on GOBIN="$PWD" GOPATH="$PWD"  go get golang.org/x/tools/gopls@latest;
-! command -v ./gopls &> /dev/null; 
+command -v ./gopls &> /dev/null; 
 
 ]=]
 

--- a/lua/nvim-lsp-installer/servers/gopls.lua
+++ b/lua/nvim-lsp-installer/servers/gopls.lua
@@ -3,14 +3,9 @@ local server = require('nvim-lsp-installer.server')
 local root_dir = server.get_server_root_path('go')
 
 local install_cmd = [=[
-GO111MODULE=on GOBIN="$PWD" GOPATH="$PWD"  go get golang.org/x/tools/gopls@latest;
 
-if ! command -v ./gopls &> /dev/null; 
-then 
-  echo "something went wrong!"
-else 
-  echo "installation completed"
-fi
+GO111MODULE=on GOBIN="$PWD" GOPATH="$PWD"  go get golang.org/x/tools/gopls@latest;
+! command -v ./gopls &> /dev/null; 
 
 ]=]
 
@@ -24,6 +19,6 @@ return server.Server:new {
   end,
   install_cmd = install_cmd,
   default_options = {
-    cmd = {root_dir .. "/gopls"},
+    cmd = {root_dir .. "/gopls", "-logfile=/home/ecmm/log"},
   }
 }

--- a/lua/nvim-lsp-installer/servers/gopls.lua
+++ b/lua/nvim-lsp-installer/servers/gopls.lua
@@ -1,0 +1,31 @@
+local server = require('nvim-lsp-installer.server')
+
+local root_dir = server.get_server_root_path('go')
+
+local install_cmd = [=[
+if ! command -v go &> /dev/null;
+then 
+  echo "Please install the Go CLI before installing gopls.";
+  echo "refer to https://golang.org/doc/install";
+  exit 1;
+fi
+
+GO111MODULE=on go get golang.org/x/tools/gopls@latest;
+
+if ! command -v gopls &> /dev/null; 
+then 
+  echo "something went wrong!"
+else 
+  echo "installation completed"
+fi
+
+]=]
+
+return server.Server:new {
+  name = "gopls",
+  root_dir = root_dir,
+  install_cmd = install_cmd,
+  default_options = {
+    cmd = {"gopls"},
+  }
+}

--- a/lua/nvim-lsp-installer/servers/gopls.lua
+++ b/lua/nvim-lsp-installer/servers/gopls.lua
@@ -3,13 +3,6 @@ local server = require('nvim-lsp-installer.server')
 local root_dir = server.get_server_root_path('go')
 
 local install_cmd = [=[
-if ! command -v go &> /dev/null;
-then 
-  echo "Please install the Go CLI before installing gopls.";
-  echo "refer to https://golang.org/doc/install";
-  exit 1;
-fi
-
 GO111MODULE=on go get golang.org/x/tools/gopls@latest;
 
 if ! command -v gopls &> /dev/null; 
@@ -24,6 +17,11 @@ fi
 return server.Server:new {
   name = "gopls",
   root_dir = root_dir,
+  pre_install_check = function ()
+    if vim.fn.executable("go") ~= 1 then
+      error("Please install the Go CLI before installing gopls (https://golang.org/doc/install).")
+    end
+  end,
   install_cmd = install_cmd,
   default_options = {
     cmd = {"gopls"},

--- a/lua/nvim-lsp-installer/servers/gopls.lua
+++ b/lua/nvim-lsp-installer/servers/gopls.lua
@@ -3,9 +3,9 @@ local server = require('nvim-lsp-installer.server')
 local root_dir = server.get_server_root_path('go')
 
 local install_cmd = [=[
-GO111MODULE=on go get golang.org/x/tools/gopls@latest;
+GO111MODULE=on GOBIN="$PWD" GOPATH="$PWD"  go get golang.org/x/tools/gopls@latest;
 
-if ! command -v gopls &> /dev/null; 
+if ! command -v ./gopls &> /dev/null; 
 then 
   echo "something went wrong!"
 else 
@@ -24,6 +24,6 @@ return server.Server:new {
   end,
   install_cmd = install_cmd,
   default_options = {
-    cmd = {"gopls"},
+    cmd = {root_dir .. "/gopls"},
   }
 }


### PR DESCRIPTION
This adds a basic gopls server configuration for Go source files. 
Since installing gopls requires the Go CLI, I thought that it would be better to avoid installing the CLI itself here, and it just aborts if Go isn't found in the system. Also, I don't think there's much control over the installation of the server itself, so `install_cmd` just checks if `gopls` exists afterwards. 

Tested on Linux 5.11.10-arch1-1, but it should work fine for other Go-supported systems as well.
If I got anything wrong, I'm happy to fix it!
(hello again! :)) 