### PR TITLE
export proper location of haskell language servers

### DIFF
--- a/lua/nvim-lsp-installer/servers/hls/install.mjs
+++ b/lua/nvim-lsp-installer/servers/hls/install.mjs
@@ -22,7 +22,9 @@ await $`rm hls.tar.gz`;
 await $`chmod +x haskell*`;
 
 const scriptContent = `#!/usr/bin/env bash
-PATH="$PATH:${__dirname}" "${__dirname}/haskell-language-server-wrapper" --lsp`;
+HLS_DIR=$(dirname "$0")
+export PATH=$PATH:$HLS_DIR
+haskell-language-server-wrapper --lsp`;
 
 await fs.writeFile("./hls", scriptContent);
 await $`chmod +x hls`


### PR DESCRIPTION
`${__dirname}` was exporting the location of the `Packer` installation folder, instead of the location of the Haskell language servers and `hls` script. This change fixes the issue for me.