### PR TITLE
add diagnostic-languageserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,52 +90,53 @@ end
 
 ## Available LSPs
 
-| Language                      | Server name              |
-| ----------------------------- | ------------------------ |
-| Angular                       | `angularls`              |
-| Ansible                       | `ansiblels`              |
-| Bash                          | `bashls`                 |
-| C#                            | `omnisharp`              |
-| C++                           | `clangd`                 |
-| CMake                         | `cmake`                  |
-| CSS                           | `cssls`                  |
-| Clojure                       | `clojure_lsp`            |
-| Deno                          | `denols`                 |
-| Docker                        | `dockerls`               |
-| EFM (general purpose server)  | `efm`                    |
-| ESLint [(docs)][eslintls]     | `eslintls`               |
-| Elixir                        | `elixirls`               |
-| Elm                           | `elmls`                  |
-| Ember                         | `ember`                  |
-| Fortran                       | `fortls`                 |
-| Go                            | `gopls`                  |
-| GraphQL                       | `graphql`                |
-| Groovy                        | `groovyls`               |
-| HTML                          | `html`                   |
-| Haskell                       | `hls`                    |
-| JSON                          | `jsonls`                 |
-| Jedi                          | `jedi_language_server`   |
-| Kotlin                        | `kotlin_language_server` |
-| LaTeX                         | `texlab`                 |
-| Lua                           | `sumneko_lua`            |
-| PHP                           | `intelephense`           |
-| PureScript                    | `purescriptls`           |
-| Python                        | `pylsp`                  |
-| Python                        | `pyright`                |
-| Rome                          | `rome`                   |
-| Ruby                          | `solargraph`             |
-| Rust                          | `rust_analyzer`          |
-| SQL                           | `sqlls`                  |
-| SQL                           | `sqls`                   |
-| Stylelint                     | `stylelint_lsp`          |
-| Svelte                        | `svelte`                 |
-| Tailwind CSS                  | `tailwindcss`            |
-| Terraform                     | `terraformls`            |
-| Terraform [(docs)][tflint]    | `tflint`                 |
-| TypeScript [(docs)][tsserver] | `tsserver`               |
-| VimL                          | `vimls`                  |
-| Vue                           | `vuels`                  |
-| YAML                          | `yamlls`                 |
+| Language                            | Server name              |
+| ----------------------------------- | ------------------------ |
+| Angular                             | `angularls`              |
+| Ansible                             | `ansiblels`              |
+| Bash                                | `bashls`                 |
+| C#                                  | `omnisharp`              |
+| C++                                 | `clangd`                 |
+| CMake                               | `cmake`                  |
+| CSS                                 | `cssls`                  |
+| Clojure                             | `clojure_lsp`            |
+| Deno                                | `denols`                 |
+| Diagnostic (general purpose server) | `diagnosticls`           |
+| Docker                              | `dockerls`               |
+| EFM (general purpose server)        | `efm`                    |
+| ESLint [(docs)][eslintls]           | `eslintls`               |
+| Elixir                              | `elixirls`               |
+| Elm                                 | `elmls`                  |
+| Ember                               | `ember`                  |
+| Fortran                             | `fortls`                 |
+| Go                                  | `gopls`                  |
+| GraphQL                             | `graphql`                |
+| Groovy                              | `groovyls`               |
+| HTML                                | `html`                   |
+| Haskell                             | `hls`                    |
+| JSON                                | `jsonls`                 |
+| Jedi                                | `jedi_language_server`   |
+| Kotlin                              | `kotlin_language_server` |
+| LaTeX                               | `texlab`                 |
+| Lua                                 | `sumneko_lua`            |
+| PHP                                 | `intelephense`           |
+| PureScript                          | `purescriptls`           |
+| Python                              | `pylsp`                  |
+| Python                              | `pyright`                |
+| Rome                                | `rome`                   |
+| Ruby                                | `solargraph`             |
+| Rust                                | `rust_analyzer`          |
+| SQL                                 | `sqlls`                  |
+| SQL                                 | `sqls`                   |
+| Stylelint                           | `stylelint_lsp`          |
+| Svelte                              | `svelte`                 |
+| Tailwind CSS                        | `tailwindcss`            |
+| Terraform                           | `terraformls`            |
+| Terraform [(docs)][tflint]          | `tflint`                 |
+| TypeScript [(docs)][tsserver]       | `tsserver`               |
+| VimL                                | `vimls`                  |
+| Vue                                 | `vuels`                  |
+| YAML                                | `yamlls`                 |
 
 [eslintls]: ./lua/nvim-lsp-installer/servers/eslintls/README.md
 [tflint]: ./lua/nvim-lsp-installer/servers/tflint/README.md

--- a/lua/nvim-lsp-installer.lua
+++ b/lua/nvim-lsp-installer.lua
@@ -13,6 +13,7 @@ local _SERVERS = {
     ["cmake"] = require "nvim-lsp-installer.servers.cmake",
     ["cssls"] = require "nvim-lsp-installer.servers.cssls",
     ["denols"] = require "nvim-lsp-installer.servers.denols",
+    ["diagnosticls"] = require "nvim-lsp-installer.servers.diagnosticls",
     ["dockerls"] = require "nvim-lsp-installer.servers.dockerls",
     ["efm"] = require "nvim-lsp-installer.servers.efm",
     ["elixirls"] = require "nvim-lsp-installer.servers.elixirls",

--- a/lua/nvim-lsp-installer/servers/diagnosticls/init.lua
+++ b/lua/nvim-lsp-installer/servers/diagnosticls/init.lua
@@ -1,0 +1,13 @@
+local server = require "nvim-lsp-installer.server"
+local npm = require "nvim-lsp-installer.installers.npm"
+
+local root_dir = server.get_server_root_path "diagnosticls"
+
+return server.Server:new {
+	name = "diagnosticls",
+	root_dir = root_dir,
+	installer = npm.packages { "diagnostic-languageserver" },
+	default_options = {
+		cmd = { npm.executable(root_dir, "diagnostic-languageserver"), "--stdio" },
+	},
+}


### PR DESCRIPTION
This PR added support for [diagnostic-languageserver](https://github.com/iamcco/diagnostic-languageserver), a general-purpose language server like efm.