### PR TITLE
vscode-langservers-extracted: use correct root dir when producing cmd path

### DIFF
--- a/lua/nvim-lsp-installer/opts.lua
+++ b/lua/nvim-lsp-installer/opts.lua
@@ -1,0 +1,20 @@
+local M = {}
+
+local function boolean_val(val)
+    if type(val) == "nil" then
+        return true
+    elseif type(val) == "number" then
+        return val == 1
+    end
+    return val and true or false
+end
+
+function M.allow_federated_servers()
+    return boolean_val(vim.g.lsp_installer_allow_federated_servers)
+end
+
+function Test()
+    print(boolean_val(vim.g.lsp_installer_allow_federated_servers))
+end
+
+return M

--- a/lua/nvim-lsp-installer/servers/vscode-langservers-extracted/init.lua
+++ b/lua/nvim-lsp-installer/servers/vscode-langservers-extracted/init.lua
@@ -1,15 +1,18 @@
 local server = require "nvim-lsp-installer.server"
+local opts = require "nvim-lsp-installer.opts"
 local npm = require "nvim-lsp-installer.installers.npm"
 
 local root_dir = server.get_server_root_path "vscode-langservers-extracted"
 
 return function(name, executable)
+    local resolved_root_dir = opts.allow_federated_servers() and root_dir or ("%s_%s"):format(root_dir, name)
+
     return server.Server:new {
         name = name,
-        root_dir = vim.g.lsp_installer_allow_federated_servers and root_dir or ("%s_%s"):format(root_dir, name),
+        root_dir = resolved_root_dir,
         installer = npm.packages { "vscode-langservers-extracted" },
         default_options = {
-            cmd = { npm.executable(root_dir, executable), "--stdio" },
+            cmd = { npm.executable(resolved_root_dir, executable), "--stdio" },
         },
     }
 end


### PR DESCRIPTION
Resolves #74.