### PR TITLE
lazily require servers for faster startup times

### DIFF
--- a/lua/nvim-lsp-installer.lua
+++ b/lua/nvim-lsp-installer.lua
@@ -3,66 +3,97 @@ local dispatcher = require "nvim-lsp-installer.dispatcher"
 
 local M = {}
 
+function Set(list)
+    local set = {}
+    for _, l in ipairs(list) do
+        set[l] = true
+    end
+    return set
+end
+
 -- :'<,'>!sort
-local _SERVERS = {
-    ["angularls"] = require "nvim-lsp-installer.servers.angularls",
-    ["ansiblels"] = require "nvim-lsp-installer.servers.ansiblels",
-    ["bashls"] = require "nvim-lsp-installer.servers.bashls",
-    ["clangd"] = require "nvim-lsp-installer.servers.clangd",
-    ["clojure_lsp"] = require "nvim-lsp-installer.servers.clojure_lsp",
-    ["cmake"] = require "nvim-lsp-installer.servers.cmake",
-    ["cssls"] = require "nvim-lsp-installer.servers.cssls",
-    ["denols"] = require "nvim-lsp-installer.servers.denols",
-    ["diagnosticls"] = require "nvim-lsp-installer.servers.diagnosticls",
-    ["dockerls"] = require "nvim-lsp-installer.servers.dockerls",
-    ["efm"] = require "nvim-lsp-installer.servers.efm",
-    ["elixirls"] = require "nvim-lsp-installer.servers.elixirls",
-    ["elmls"] = require "nvim-lsp-installer.servers.elmls",
-    ["ember"] = require "nvim-lsp-installer.servers.ember",
-    ["eslintls"] = require "nvim-lsp-installer.servers.eslintls",
-    ["fortls"] = require "nvim-lsp-installer.servers.fortls",
-    ["gopls"] = require "nvim-lsp-installer.servers.gopls",
-    ["graphql"] = require "nvim-lsp-installer.servers.graphql",
-    ["groovyls"] = require "nvim-lsp-installer.servers.groovyls",
-    ["hls"] = require "nvim-lsp-installer.servers.hls",
-    ["html"] = require "nvim-lsp-installer.servers.html",
-    ["intelephense"] = require "nvim-lsp-installer.servers.intelephense",
-    ["jedi_language_server"] = require "nvim-lsp-installer.servers.jedi_language_server",
-    ["jsonls"] = require "nvim-lsp-installer.servers.jsonls",
-    ["kotlin_language_server"] = require "nvim-lsp-installer.servers.kotlin_language_server",
-    ["omnisharp"] = require "nvim-lsp-installer.servers.omnisharp",
-    ["purescriptls"] = require "nvim-lsp-installer.servers.purescriptls",
-    ["pylsp"] = require "nvim-lsp-installer.servers.pylsp",
-    ["pyright"] = require "nvim-lsp-installer.servers.pyright",
-    ["rescriptls"] = require "nvim-lsp-installer.servers.rescriptls",
-    ["rome"] = require "nvim-lsp-installer.servers.rome",
-    ["rust_analyzer"] = require "nvim-lsp-installer.servers.rust_analyzer",
-    ["solargraph"] = require "nvim-lsp-installer.servers.solargraph",
-    ["sqlls"] = require "nvim-lsp-installer.servers.sqlls",
-    ["sqls"] = require "nvim-lsp-installer.servers.sqls",
-    ["stylelint_lsp"] = require "nvim-lsp-installer.servers.stylelint_lsp",
-    ["sumneko_lua"] = require "nvim-lsp-installer.servers.sumneko_lua",
-    ["svelte"] = require "nvim-lsp-installer.servers.svelte",
-    ["tailwindcss"] = require "nvim-lsp-installer.servers.tailwindcss",
-    ["terraformls"] = require "nvim-lsp-installer.servers.terraformls",
-    ["texlab"] = require "nvim-lsp-installer.servers.texlab",
-    ["tflint"] = require "nvim-lsp-installer.servers.tflint",
-    ["tsserver"] = require "nvim-lsp-installer.servers.tsserver",
-    ["vimls"] = require "nvim-lsp-installer.servers.vimls",
-    ["vuels"] = require "nvim-lsp-installer.servers.vuels",
-    ["yamlls"] = require "nvim-lsp-installer.servers.yamlls",
+local CORE_SERVERS = Set {
+    "angularls",
+    "ansiblels",
+    "bashls",
+    "clangd",
+    "clojure_lsp",
+    "cmake",
+    "cssls",
+    "denols",
+    "diagnosticls",
+    "dockerls",
+    "efm",
+    "elixirls",
+    "elmls",
+    "ember",
+    "eslintls",
+    "fortls",
+    "gopls",
+    "graphql",
+    "groovyls",
+    "hls",
+    "html",
+    "intelephense",
+    "jedi_language_server",
+    "jsonls",
+    "kotlin_language_server",
+    "omnisharp",
+    "purescriptls",
+    "pylsp",
+    "pyright",
+    "rescriptls",
+    "rome",
+    "rust_analyzer",
+    "solargraph",
+    "sqlls",
+    "sqls",
+    "stylelint_lsp",
+    "sumneko_lua",
+    "svelte",
+    "tailwindcss",
+    "terraformls",
+    "texlab",
+    "tflint",
+    "tsserver",
+    "vimls",
+    "vuels",
+    "yamlls",
 }
 
+local CUSTOM_SERVERS_MAP = {}
+
 function M.get_server(server_name)
-    local server = _SERVERS[server_name]
-    if server then
+    -- Registered custom servers have precedence
+    if CUSTOM_SERVERS_MAP[server_name] then
+        return true, CUSTOM_SERVERS_MAP[server_name]
+    end
+
+    if not CORE_SERVERS[server_name] then
+        return false, ("Server %s does not exist."):format(server_name)
+    end
+
+    local ok, server = pcall(require, ("nvim-lsp-installer.servers.%s"):format(server_name))
+    if ok then
         return true, server
     end
-    return false, ("Server %s does not exist."):format(server_name)
+    return false,
+        ("Unable to import server %s. This is an unexpected error, please file an issue at %s"):format(
+            server_name,
+            "https://github.com/williamboman/nvim-lsp-installer"
+        )
 end
 
 function M.get_available_servers()
-    return vim.tbl_values(_SERVERS)
+    return vim.tbl_map(function(server_name)
+        local ok, server = M.get_server(server_name)
+        if not ok then
+            error(server)
+        end
+        return server
+    end, vim.tbl_keys(
+        vim.tbl_extend("force", CORE_SERVERS, CUSTOM_SERVERS_MAP)
+    ))
 end
 
 function M.get_installed_servers()
@@ -103,7 +134,7 @@ function M.uninstall(server_name)
 end
 
 function M.register(server)
-    _SERVERS[server.name] = server
+    CUSTOM_SERVERS_MAP[server.name] = server
 end
 
 function M.on_server_ready(cb)

--- a/lua/nvim-lsp-installer.lua
+++ b/lua/nvim-lsp-installer.lua
@@ -78,10 +78,9 @@ function M.get_server(server_name)
         return true, server
     end
     return false,
-        ("Unable to import server %s. This is an unexpected error, please file an issue at %s"):format(
-            server_name,
-            "https://github.com/williamboman/nvim-lsp-installer"
-        )
+        (
+            "Unable to import server %s.\n\nThis is an unexpected error, please file an issue at %s with the following information:\n%s"
+        ):format(server_name, "https://github.com/williamboman/nvim-lsp-installer", server)
 end
 
 function M.get_available_servers()


### PR DESCRIPTION
Speeds up `require("nvim-lsp-installer")` from ~50ms to ~2ms, a 96% decrease (YMMV).