### PR TITLE
optimize io (70%+ startup speedups)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,18 @@ LSP servers locally (inside `:echo stdpath("data")`).
 On top of just providing commands for installing & uninstalling LSP servers, it:
 
 -   provides a graphical UI
+-   optimized for blazing fast startup times
 -   provides configurations for servers that aren't supported by nvim-lspconfig (`eslint`)
 -   common install tasks are abstracted behind Lua APIs (has direct integration with libuv via vim.loop)
 -   <img src="https://user-images.githubusercontent.com/6705160/131256603-cacf7f66-dfa9-4515-8ae4-0e42d08cfc6a.png" height="20"> full support for Windows
 
 ## Installation
 
-Requires neovim `>= 0.5.0`. These are the full requirements to install all servers:
+Requires neovim `>= 0.5.0` and [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig). The full requirements to
+install all servers are:
 
--   neovim/nvim-lspconfig (https://github.com/neovim/nvim-lspconfig)
 -   For Unix systems: bash(1), git(1), wget(1), unzip(1), tar(1), gzip(1)
--   For Windows systems: powershell.exe, tar, git
+-   For Windows systems: powershell, git, gzip, tar
 -   Node.js (LTS) & npm
 -   Python3 & pip3
 -   go

--- a/doc/nvim-lsp-installer.txt
+++ b/doc/nvim-lsp-installer.txt
@@ -10,12 +10,11 @@ INTRODUCTION                                *nvim-lsp-installer-introduction*
 Semi-opinionated companion plugin for nvim-lspconfig. It comes with all
 batteries included, or at least to the extent possible.
 
-Requires neovim `>= 0.5.0`. These are the full requirements to install all
-servers:
+Requires neovim `>= 0.5.0` and [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig). The full requirements to
+install all servers are:
 
--   neovim/nvim-lspconfig (https://github.com/neovim/nvim-lspconfig)
 -   For Unix systems: bash(1), git(1), wget(1), unzip(1), tar(1), gzip(1)
--   For Windows systems: powershell.exe, tar, git
+-   For Windows systems: powershell, git, gzip, tar
 -   Node.js (LTS) & npm
 -   Python3 & pip3
 -   go

--- a/lua/nvim-lsp-installer.lua
+++ b/lua/nvim-lsp-installer.lua
@@ -1,5 +1,6 @@
 local notify = require "nvim-lsp-installer.notify"
 local dispatcher = require "nvim-lsp-installer.dispatcher"
+local process = require "nvim-lsp-installer.process"
 local status_win = require "nvim-lsp-installer.ui.status-win"
 local servers = require "nvim-lsp-installer.servers"
 
@@ -55,18 +56,10 @@ end
 
 -- "Proxy" function for triggering attachment of LSP servers to all buffers (useful when just installed a new server
 -- that wasn't installed at launch)
-local queued = false
-function M.lsp_attach_proxy()
-    if queued then
-        return
-    end
-    queued = true
-    vim.schedule(function()
-        -- As of writing, if the lspconfig server provides a filetypes setting, it uses FileType as trigger, otherwise it uses BufReadPost
-        vim.cmd [[ doautoall FileType | doautoall BufReadPost ]]
-        queued = false
-    end)
-end
+M.lsp_attach_proxy = process.debounced(function()
+    -- As of writing, if the lspconfig server provides a filetypes setting, it uses FileType as trigger, otherwise it uses BufReadPost
+    vim.cmd [[ doautoall FileType | doautoall BufReadPost ]]
+end)
 
 -- old API
 M.get_server = servers.get_server

--- a/lua/nvim-lsp-installer/fs.lua
+++ b/lua/nvim-lsp-installer/fs.lua
@@ -1,4 +1,4 @@
-local pathm = require("nvim-lsp-installer.path")
+local pathm = require "nvim-lsp-installer.path"
 
 local uv = vim.loop
 local M = {}
@@ -44,6 +44,27 @@ function M.fstat(path)
     local fstat = assert(uv.fs_fstat(fd))
     assert(uv.fs_close(fd))
     return fstat
+end
+
+function M.readdir(path)
+    local dir = assert(uv.fs_opendir(path, nil, 25))
+    local all_entries = {}
+    local exhausted = false
+
+    repeat
+        local entries = uv.fs_readdir(dir)
+        if entries and #entries > 0 then
+            for i = 1, #entries do
+                all_entries[#all_entries + 1] = entries[i]
+            end
+        else
+            exhausted = true
+        end
+    until exhausted
+
+    assert(uv.fs_closedir(dir))
+
+    return all_entries
 end
 
 return M

--- a/lua/nvim-lsp-installer/installers/gem.lua
+++ b/lua/nvim-lsp-installer/installers/gem.lua
@@ -1,5 +1,7 @@
 local path = require "nvim-lsp-installer.path"
 local process = require "nvim-lsp-installer.process"
+local installers = require "nvim-lsp-installer.installers"
+local std = require "nvim-lsp-installer.installers.std"
 local platform = require "nvim-lsp-installer.platform"
 
 local M = {}
@@ -7,20 +9,26 @@ local M = {}
 local gem = platform.is_win and "gem.cmd" or "gem"
 
 function M.packages(packages)
-    return function(server, callback, context)
-        process.spawn(gem, {
-            args = {
-                "install",
-                "--no-user-install",
-                "--install-dir=.",
-                "--bindir=bin",
-                "--no-document",
-                table.concat(packages, " "),
-            },
-            cwd = server.root_dir,
-            stdio_sink = context.stdio_sink,
-        }, callback)
-    end
+    return installers.pipe {
+        std.ensure_executables {
+            { "ruby", "ruby was not found in path, refer to https://wiki.openstack.org/wiki/RubyGems." },
+            { "gem", "gem was not found in path, refer to https://wiki.openstack.org/wiki/RubyGems." },
+        },
+        function(server, callback, context)
+            process.spawn(gem, {
+                args = {
+                    "install",
+                    "--no-user-install",
+                    "--install-dir=.",
+                    "--bindir=bin",
+                    "--no-document",
+                    table.concat(packages, " "),
+                },
+                cwd = server.root_dir,
+                stdio_sink = context.stdio_sink,
+            }, callback)
+        end,
+    }
 end
 
 function M.executable(root_dir, executable)

--- a/lua/nvim-lsp-installer/installers/go.lua
+++ b/lua/nvim-lsp-installer/installers/go.lua
@@ -1,25 +1,30 @@
 local path = require "nvim-lsp-installer.path"
+local std = require "nvim-lsp-installer.installers.std"
+local installers = require "nvim-lsp-installer.installers"
 local process = require "nvim-lsp-installer.process"
 
 local M = {}
 
 function M.packages(packages)
-    return function(server, callback, context)
-        local c = process.chain {
-            env = process.graft_env {
-                GO111MODULE = "on",
-                GOBIN = server.root_dir,
-                GOPATH = server.root_dir,
-            },
-            cwd = server.root_dir,
-            stdio_sink = context.stdio_sink,
-        }
+    return installers.pipe {
+        std.ensure_executables { { "go", "go was not found in path, refer to https://golang.org/doc/install." } },
+        function(server, callback, context)
+            local c = process.chain {
+                env = process.graft_env {
+                    GO111MODULE = "on",
+                    GOBIN = server.root_dir,
+                    GOPATH = server.root_dir,
+                },
+                cwd = server.root_dir,
+                stdio_sink = context.stdio_sink,
+            }
 
-        c.run("go", vim.list_extend({ "get", "-v" }, packages))
-        c.run("go", { "clean", "-modcache" })
+            c.run("go", vim.list_extend({ "get", "-v" }, packages))
+            c.run("go", { "clean", "-modcache" })
 
-        c.spawn(callback)
-    end
+            c.spawn(callback)
+        end,
+    }
 end
 
 function M.executable(root_dir, executable)

--- a/lua/nvim-lsp-installer/installers/init.lua
+++ b/lua/nvim-lsp-installer/installers/init.lua
@@ -42,7 +42,11 @@ function M.always_succeed(installer)
 end
 
 local function get_by_platform(platform_table)
-    if platform.is_unix then
+    if platform.is_mac then
+        return platform_table.mac or platform_table.unix
+    elseif platform.is_linux then
+        return platform_table.linux or platform_table.unix
+    elseif platform.is_unix then
         return platform_table.unix
     elseif platform.is_win then
         return platform_table.win

--- a/lua/nvim-lsp-installer/installers/npm.lua
+++ b/lua/nvim-lsp-installer/installers/npm.lua
@@ -1,4 +1,6 @@
 local path = require "nvim-lsp-installer.path"
+local installers = require "nvim-lsp-installer.installers"
+local std = require "nvim-lsp-installer.installers.std"
 local platform = require "nvim-lsp-installer.platform"
 local process = require "nvim-lsp-installer.process"
 
@@ -6,34 +8,47 @@ local M = {}
 
 local npm = platform.is_win and "npm.cmd" or "npm"
 
+local function ensure_npm(installer)
+    return installers.pipe {
+        std.ensure_executables {
+            { "node", "node was not found in path. Refer to https://nodejs.org/en/." },
+            {
+                "npm",
+                "npm was not found in path. Refer to https://docs.npmjs.com/downloading-and-installing-node-js-and-npm.",
+            },
+        },
+        installer,
+    }
+end
+
 function M.packages(packages)
-    return function(server, callback, context)
+    return ensure_npm(function(server, callback, context)
         process.spawn(npm, {
             args = vim.list_extend({ "install" }, packages),
             cwd = server.root_dir,
             stdio_sink = context.stdio_sink,
         }, callback)
-    end
+    end)
 end
 
 function M.install(production)
-    return function(server, callback, context)
+    return ensure_npm(function(server, callback, context)
         process.spawn(npm, {
             args = production and { "install", "--production" } or { "install" },
             cwd = server.root_dir,
             stdio_sink = context.stdio_sink,
         }, callback)
-    end
+    end)
 end
 
 function M.run(script)
-    return function(server, callback, context)
+    return ensure_npm(function(server, callback, context)
         process.spawn(npm, {
             args = { "run", script },
             cwd = server.root_dir,
             stdio_sink = context.stdio_sink,
         }, callback)
-    end
+    end)
 end
 
 function M.executable(root_dir, executable)

--- a/lua/nvim-lsp-installer/installers/pip3.lua
+++ b/lua/nvim-lsp-installer/installers/pip3.lua
@@ -1,4 +1,6 @@
 local path = require "nvim-lsp-installer.path"
+local installers = require "nvim-lsp-installer.installers"
+local std = require "nvim-lsp-installer.installers.std"
 local platform = require "nvim-lsp-installer.platform"
 local process = require "nvim-lsp-installer.process"
 
@@ -7,17 +9,23 @@ local M = {}
 local REL_INSTALL_DIR = "venv"
 
 function M.packages(packages)
-    return function(server, callback, context)
-        local c = process.chain {
-            cwd = server.root_dir,
-            stdio_sink = context.stdio_sink,
-        }
+    return installers.pipe {
+        std.ensure_executables {
+            { "python3", "python3 was not found in path. Refer to https://www.python.org/downloads/." },
+            { "pip3", "pip3 was not found in path." },
+        },
+        function(server, callback, context)
+            local c = process.chain {
+                cwd = server.root_dir,
+                stdio_sink = context.stdio_sink,
+            }
 
-        c.run("python3", { "-m", "venv", REL_INSTALL_DIR })
-        c.run(M.executable(server.root_dir, "pip3"), vim.list_extend({ "install", "-U" }, packages))
+            c.run("python3", { "-m", "venv", REL_INSTALL_DIR })
+            c.run(M.executable(server.root_dir, "pip3"), vim.list_extend({ "install", "-U" }, packages))
 
-        c.spawn(callback)
-    end
+            c.spawn(callback)
+        end,
+    }
 end
 
 function M.executable(root_dir, executable)

--- a/lua/nvim-lsp-installer/installers/std.lua
+++ b/lua/nvim-lsp-installer/installers/std.lua
@@ -118,9 +118,11 @@ end
 function M.ensure_executables(executables)
     return vim.schedule_wrap(function(_, callback, context)
         for i = 1, #executables do
-            local executable = executables[i]
+            local entry = executables[i]
+            local executable = entry[1]
+            local error_msg = entry[2]
             if vim.fn.executable(executable) ~= 1 then
-                context.stdio_sink.stderr(("Missing required %q executable."):format(executable))
+                context.stdio_sink.stderr(error_msg)
                 callback(false)
                 return
             end

--- a/lua/nvim-lsp-installer/platform.lua
+++ b/lua/nvim-lsp-installer/platform.lua
@@ -11,6 +11,7 @@ M.arch = arch_aliases[uname.machine] or uname.machine
 M.is_win = vim.fn.has "win32" == 1
 M.is_unix = vim.fn.has "unix" == 1
 M.is_mac = vim.fn.has "mac" == 1
+M.is_linux = not M.is_mac and M.is_unix
 
 -- PATH separator
 M.path_sep = M.is_win and ";" or ":"

--- a/lua/nvim-lsp-installer/server.lua
+++ b/lua/nvim-lsp-installer/server.lua
@@ -1,14 +1,13 @@
 local dispatcher = require "nvim-lsp-installer.dispatcher"
 local fs = require "nvim-lsp-installer.fs"
 local installers = require "nvim-lsp-installer.installers"
-local path = require "nvim-lsp-installer.path"
+local servers = require "nvim-lsp-installer.servers"
 local status_win = require "nvim-lsp-installer.ui.status-win"
 
 local M = {}
 
-function M.get_server_root_path(server)
-    return path.concat { path.SERVERS_ROOT_DIR, server }
-end
+-- old, but also somewhat convenient, API
+M.get_server_root_path = servers.get_server_install_path
 
 M.Server = {}
 M.Server.__index = M.Server
@@ -17,14 +16,14 @@ M.Server.__index = M.Server
 --@param opts table
 -- @field name (string)                  The name of the LSP server. This MUST correspond with lspconfig's naming.
 --
--- @field root_dir (string)              The root directory of the installation. Most servers will make use of server.get_server_root_path() to produce its root_dir path.
---
 -- @field installer (function)           The function that installs the LSP (see the .installers module). The function signature should be `function (server, callback)`, where
 --                                       `server` is the Server instance being installed, and `callback` is a function that must be called upon completion. The `callback` function
 --                                       has the signature `function (success, result)`, where `success` is a boolean and `result` is of any type (similar to `pcall`).
 --
 -- @field default_options (table)        The default options to be passed to lspconfig's .setup() function. Each server should provide at least the `cmd` field.
 --
+-- @field root_dir (string)              The absolute path to the directory of the installation.
+--                                       This MUST be a directory inside nvim-lsp-installer's designated root install directory inside stdpath("data"). Most servers will make use of server.get_server_root_path() to produce its root_dir path.
 --
 -- @field post_setup (function)          An optional function to be executed after the setup function has been successfully called.
 --                                       Use this to defer setting up server specific things until they're actually
@@ -68,7 +67,7 @@ function M.Server:get_default_options()
 end
 
 function M.Server:is_installed()
-    return fs.dir_exists(self.root_dir)
+    return servers.is_server_installed(self.name)
 end
 
 function M.Server:create_root_dir()

--- a/lua/nvim-lsp-installer/servers/angularls/init.lua
+++ b/lua/nvim-lsp-installer/servers/angularls/init.lua
@@ -11,37 +11,36 @@ local function get_probe_dir(root_dir)
     return project_root and (project_root .. "/node_modules") or ""
 end
 
-local default_probe_dir = get_probe_dir(vim.fn.getcwd())
+return function(name, root_dir)
+    local default_probe_dir = get_probe_dir(vim.fn.getcwd())
+    local executable_path = npm.executable(root_dir, "ngserver")
 
-local root_dir = server.get_server_root_path "angularls"
-
-local executable_path = npm.executable(root_dir, "ngserver")
-
-return server.Server:new {
-    name = "angularls",
-    root_dir = root_dir,
-    installer = npm.packages { "@angular/language-server" },
-    default_options = {
-        cmd = {
-            executable_path,
-            "--stdio",
-            "--tsProbeLocations",
-            default_probe_dir,
-            "--ngProbeLocations",
-            default_probe_dir,
-        },
-        on_new_config = function(new_config, new_root_dir)
-            local new_probe_dir = get_probe_dir(new_root_dir)
-
-            -- We need to check our probe directories because they may have changed.
-            new_config.cmd = {
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "@angular/language-server" },
+        default_options = {
+            cmd = {
                 executable_path,
                 "--stdio",
                 "--tsProbeLocations",
-                new_probe_dir,
+                default_probe_dir,
                 "--ngProbeLocations",
-                new_probe_dir,
-            }
-        end,
-    },
-}
+                default_probe_dir,
+            },
+            on_new_config = function(new_config, new_root_dir)
+                local new_probe_dir = get_probe_dir(new_root_dir)
+
+                -- We need to check our probe directories because they may have changed.
+                new_config.cmd = {
+                    executable_path,
+                    "--stdio",
+                    "--tsProbeLocations",
+                    new_probe_dir,
+                    "--ngProbeLocations",
+                    new_probe_dir,
+                }
+            end,
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/ansiblels/init.lua
+++ b/lua/nvim-lsp-installer/servers/ansiblels/init.lua
@@ -3,19 +3,19 @@ local path = require "nvim-lsp-installer.path"
 local std = require "nvim-lsp-installer.installers.std"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "ansiblels"
-
-return server.Server:new {
-    name = "ansiblels",
-    root_dir = root_dir,
-    installer = {
-        std.git_clone "https://github.com/ansible/ansible-language-server",
-        npm.install(),
-        npm.run "compile",
-        npm.install(true),
-    },
-    default_options = {
-        filetypes = { "yaml", "yaml.ansible" },
-        cmd = { "node", path.concat { root_dir, "out", "server", "src", "server.js" }, "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = {
+            std.git_clone "https://github.com/ansible/ansible-language-server",
+            npm.install(),
+            npm.run "compile",
+            npm.install(true),
+        },
+        default_options = {
+            filetypes = { "yaml", "yaml.ansible" },
+            cmd = { "node", path.concat { root_dir, "out", "server", "src", "server.js" }, "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/bashls/init.lua
+++ b/lua/nvim-lsp-installer/servers/bashls/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "bash"
-
-return server.Server:new {
-    name = "bashls",
-    root_dir = root_dir,
-    installer = npm.packages { "bash-language-server@latest" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "bash-language-server"), "start" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "bash-language-server@latest" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "bash-language-server"), "start" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/clangd/init.lua
+++ b/lua/nvim-lsp-installer/servers/clangd/init.lua
@@ -4,21 +4,23 @@ local platform = require "nvim-lsp-installer.platform"
 local Data = require "nvim-lsp-installer.data"
 local std = require "nvim-lsp-installer.installers.std"
 
-local root_dir = server.get_server_root_path "clangd"
-
 local VERSION = "12.0.1"
 
 local target = Data.coalesce(
     Data.when(platform.is_mac, "clangd-mac-%s.zip"),
-    Data.when(platform.is_unix, "clangd-linux-%s.zip"),
+    Data.when(platform.is_linux, "clangd-linux-%s.zip"),
     Data.when(platform.is_win, "clangd-windows-%s.zip")
 ):format(VERSION)
 
-return server.Server:new {
-    name = "clangd",
-    root_dir = root_dir,
-    installer = std.unzip_remote(("https://github.com/clangd/clangd/releases/download/%s/%s"):format(VERSION, target)),
-    default_options = {
-        cmd = { path.concat { root_dir, ("clangd_%s"):format(VERSION), "bin", "clangd" } },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = std.unzip_remote(
+            ("https://github.com/clangd/clangd/releases/download/%s/%s"):format(VERSION, target)
+        ),
+        default_options = {
+            cmd = { path.concat { root_dir, ("clangd_%s"):format(VERSION), "bin", "clangd" } },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/clojure_lsp/init.lua
+++ b/lua/nvim-lsp-installer/servers/clojure_lsp/init.lua
@@ -4,24 +4,26 @@ local std = require "nvim-lsp-installer.installers.std"
 local Data = require "nvim-lsp-installer.data"
 local platform = require "nvim-lsp-installer.platform"
 
-local root_dir = server.get_server_root_path "clojure_lsp"
-
 local VERSION = "2021.07.01-19.49.02"
 
 local target = Data.coalesce(
     Data.when(platform.is_mac, "clojure-lsp-native-macos-amd64.zip"),
-    Data.when(platform.is_unix, "clojure-lsp-native-linux-amd64.zip"),
+    Data.when(platform.is_linux, "clojure-lsp-native-linux-amd64.zip"),
     Data.when(platform.is_win, "clojure-lsp-native-windows-amd64.zip")
 )
 
-return server.Server:new {
-    name = "clojure_lsp",
-    root_dir = root_dir,
-    installer = {
-        std.unzip_remote(("https://github.com/clojure-lsp/clojure-lsp/releases/download/%s/%s"):format(VERSION, target)),
-        std.chmod("+x", { "clojure-lsp" }),
-    },
-    default_options = {
-        cmd = { path.concat { root_dir, "clojure-lsp" } },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = {
+            std.unzip_remote(
+                ("https://github.com/clojure-lsp/clojure-lsp/releases/download/%s/%s"):format(VERSION, target)
+            ),
+            std.chmod("+x", { "clojure-lsp" }),
+        },
+        default_options = {
+            cmd = { path.concat { root_dir, "clojure-lsp" } },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/cmake/init.lua
+++ b/lua/nvim-lsp-installer/servers/cmake/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local pip3 = require "nvim-lsp-installer.installers.pip3"
 
-local root_dir = server.get_server_root_path "cmake"
-
-return server.Server:new {
-    name = "cmake",
-    root_dir = root_dir,
-    installer = pip3.packages { "cmake-language-server" },
-    default_options = {
-        cmd = { pip3.executable(root_dir, "cmake-language-server") },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = pip3.packages { "cmake-language-server" },
+        default_options = {
+            cmd = { pip3.executable(root_dir, "cmake-language-server") },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/cssls/init.lua
+++ b/lua/nvim-lsp-installer/servers/cssls/init.lua
@@ -1,3 +1,1 @@
-local create_server = require "nvim-lsp-installer.servers.vscode-langservers-extracted"
-
-return create_server("cssls", "vscode-css-language-server")
+return require "nvim-lsp-installer.servers.vscode-langservers-extracted" "vscode-css-language-server"

--- a/lua/nvim-lsp-installer/servers/denols/init.lua
+++ b/lua/nvim-lsp-installer/servers/denols/init.lua
@@ -3,24 +3,24 @@ local path = require "nvim-lsp-installer.path"
 local installers = require "nvim-lsp-installer.installers"
 local shell = require "nvim-lsp-installer.installers.shell"
 
-local root_dir = server.get_server_root_path "denols"
-
-return server.Server:new {
-    name = "denols",
-    root_dir = root_dir,
-    installer = installers.when {
-        unix = shell.remote_bash("https://deno.land/x/install/install.sh", {
-            env = {
-                DENO_INSTALL = root_dir,
-            },
-        }),
-        win = shell.remote_powershell("https://deno.land/x/install/install.ps1", {
-            env = {
-                DENO_INSTALL = root_dir,
-            },
-        }),
-    },
-    default_options = {
-        cmd = { path.concat { root_dir, "bin", "deno" }, "lsp" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = installers.when {
+            unix = shell.remote_bash("https://deno.land/x/install/install.sh", {
+                env = {
+                    DENO_INSTALL = root_dir,
+                },
+            }),
+            win = shell.remote_powershell("https://deno.land/x/install/install.ps1", {
+                env = {
+                    DENO_INSTALL = root_dir,
+                },
+            }),
+        },
+        default_options = {
+            cmd = { path.concat { root_dir, "bin", "deno" }, "lsp" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/diagnosticls/init.lua
+++ b/lua/nvim-lsp-installer/servers/diagnosticls/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "diagnosticls"
-
-return server.Server:new {
-	name = "diagnosticls",
-	root_dir = root_dir,
-	installer = npm.packages { "diagnostic-languageserver" },
-	default_options = {
-		cmd = { npm.executable(root_dir, "diagnostic-languageserver"), "--stdio" },
-	},
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "diagnostic-languageserver" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "diagnostic-languageserver"), "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/dockerls/init.lua
+++ b/lua/nvim-lsp-installer/servers/dockerls/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "dockerfile"
-
-return server.Server:new {
-    name = "dockerls",
-    root_dir = root_dir,
-    installer = npm.packages { "dockerfile-language-server-nodejs@latest" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "docker-langserver"), "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "dockerfile-language-server-nodejs@latest" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "docker-langserver"), "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/dotls/init.lua
+++ b/lua/nvim-lsp-installer/servers/dotls/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "dotls"
-
-return server.Server:new {
-    name = "dotls",
-    root_dir = root_dir,
-    installer = npm.packages { "dot-language-server" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "dot-language-server"), "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "dot-language-server" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "dot-language-server"), "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/efm/init.lua
+++ b/lua/nvim-lsp-installer/servers/efm/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local go = require "nvim-lsp-installer.installers.go"
 
-local root_dir = server.get_server_root_path "efm"
-
-return server.Server:new {
-    name = "efm",
-    root_dir = root_dir,
-    installer = go.packages { "github.com/mattn/efm-langserver" },
-    default_options = {
-        cmd = { go.executable(root_dir, "efm-langserver") },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = go.packages { "github.com/mattn/efm-langserver" },
+        default_options = {
+            cmd = { go.executable(root_dir, "efm-langserver") },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/elixirls/init.lua
+++ b/lua/nvim-lsp-installer/servers/elixirls/init.lua
@@ -2,16 +2,19 @@ local server = require "nvim-lsp-installer.server"
 local path = require "nvim-lsp-installer.path"
 local std = require "nvim-lsp-installer.installers.std"
 
-local root_dir = server.get_server_root_path "elixir"
-
-return server.Server:new {
-    name = "elixirls",
-    root_dir = root_dir,
-    installer = {
-        std.unzip_remote("https://github.com/elixir-lsp/elixir-ls/releases/download/v0.8.1/elixir-ls.zip", "elixir-ls"),
-        std.chmod("+x", { "elixir-ls/language_server.sh" }),
-    },
-    default_options = {
-        cmd = { path.concat { root_dir, "elixir-ls", "language_server.sh" } },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = {
+            std.unzip_remote(
+                "https://github.com/elixir-lsp/elixir-ls/releases/download/v0.8.1/elixir-ls.zip",
+                "elixir-ls"
+            ),
+            std.chmod("+x", { "elixir-ls/language_server.sh" }),
+        },
+        default_options = {
+            cmd = { path.concat { root_dir, "elixir-ls", "language_server.sh" } },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/elmls/init.lua
+++ b/lua/nvim-lsp-installer/servers/elmls/init.lua
@@ -1,19 +1,19 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "elm"
-
-return server.Server:new {
-    name = "elmls",
-    root_dir = root_dir,
-    installer = npm.packages { "elm", "elm-test", "elm-format", "@elm-tooling/elm-language-server" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "elm-language-server") },
-        init_options = {
-            elmPath = npm.executable(root_dir, "elm"),
-            elmFormatPath = npm.executable(root_dir, "elm-format"),
-            elmTestPath = npm.executable(root_dir, "elm-test"),
-            elmAnalyseTrigger = "change",
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "elm", "elm-test", "elm-format", "@elm-tooling/elm-language-server" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "elm-language-server") },
+            init_options = {
+                elmPath = npm.executable(root_dir, "elm"),
+                elmFormatPath = npm.executable(root_dir, "elm-format"),
+                elmTestPath = npm.executable(root_dir, "elm-test"),
+                elmAnalyseTrigger = "change",
+            },
         },
-    },
-}
+    }
+end

--- a/lua/nvim-lsp-installer/servers/ember/init.lua
+++ b/lua/nvim-lsp-installer/servers/ember/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "ember"
-
-return server.Server:new {
-    name = "ember",
-    root_dir = root_dir,
-    installer = npm.packages { "@lifeart/ember-language-server" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "ember-language-server"), "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "@lifeart/ember-language-server" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "ember-language-server"), "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/eslintls/init.lua
+++ b/lua/nvim-lsp-installer/servers/eslintls/init.lua
@@ -10,82 +10,82 @@ local ConfirmExecutionResult = {
     approved = 4,
 }
 
-local root_dir = server.get_server_root_path "eslint"
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = shell.polyshell [[ git clone --depth 1 https://github.com/microsoft/vscode-eslint . && npm install && npm run compile:server ]],
+        pre_setup = function()
+            local lspconfig = require "lspconfig"
+            local configs = require "lspconfig/configs"
 
-return server.Server:new {
-    name = "eslintls",
-    root_dir = root_dir,
-    installer = shell.polyshell [[ git clone --depth 1 https://github.com/microsoft/vscode-eslint . && npm install && npm run compile:server ]],
-    pre_setup = function()
-        local lspconfig = require "lspconfig"
-        local configs = require "lspconfig/configs"
-
-        if not configs.eslintls then
-            configs.eslintls = {
-                default_config = {
-                    filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact" },
-                    root_dir = lspconfig.util.root_pattern(".eslintrc*", "package.json", ".git"),
-                    -- Refer to https://github.com/Microsoft/vscode-eslint#settings-options for documentation.
-                    settings = {
-                        validate = "on",
-                        run = "onType",
-                        codeAction = {
-                            disableRuleComment = {
-                                enable = true,
-                                -- "sameLine" might not work as expected, see https://github.com/williamboman/nvim-lsp-installer/issues/4
-                                location = "separateLine",
+            if not configs.eslintls then
+                configs.eslintls = {
+                    default_config = {
+                        filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact" },
+                        root_dir = lspconfig.util.root_pattern(".eslintrc*", "package.json", ".git"),
+                        -- Refer to https://github.com/Microsoft/vscode-eslint#settings-options for documentation.
+                        settings = {
+                            validate = "on",
+                            run = "onType",
+                            codeAction = {
+                                disableRuleComment = {
+                                    enable = true,
+                                    -- "sameLine" might not work as expected, see https://github.com/williamboman/nvim-lsp-installer/issues/4
+                                    location = "separateLine",
+                                },
+                                showDocumentation = {
+                                    enable = true,
+                                },
                             },
-                            showDocumentation = {
-                                enable = true,
+                            rulesCustomizations = {},
+                            -- Automatically determine working directory by locating .eslintrc config files.
+                            --
+                            -- It's recommended not to change this.
+                            workingDirectory = { mode = "auto" },
+                            -- If nodePath is a non-null/undefined value the eslint LSP runs into runtime exceptions.
+                            --
+                            -- It's recommended not to change this.
+                            nodePath = "",
+                            -- The "workspaceFolder" is a VSCode concept. We set it to the root
+                            -- directory to not restrict the LPS server when it traverses the
+                            -- file tree when locating a .eslintrc config file.
+                            --
+                            -- It's recommended not to change this.
+                            workspaceFolder = {
+                                uri = "/",
+                                name = "root",
                             },
-                        },
-                        rulesCustomizations = {},
-                        -- Automatically determine working directory by locating .eslintrc config files.
-                        --
-                        -- It's recommended not to change this.
-                        workingDirectory = { mode = "auto" },
-                        -- If nodePath is a non-null/undefined value the eslint LSP runs into runtime exceptions.
-                        --
-                        -- It's recommended not to change this.
-                        nodePath = "",
-                        -- The "workspaceFolder" is a VSCode concept. We set it to the root
-                        -- directory to not restrict the LPS server when it traverses the
-                        -- file tree when locating a .eslintrc config file.
-                        --
-                        -- It's recommended not to change this.
-                        workspaceFolder = {
-                            uri = "/",
-                            name = "root",
                         },
                     },
-                },
-            }
-        end
-    end,
-    default_options = {
-        cmd = { "node", path.concat { root_dir, "server", "out", "eslintServer.js" }, "--stdio" },
-        handlers = {
-            ["eslint/openDoc"] = function(_, _, open_doc)
-                os.execute(string.format("open %q", open_doc.url))
-                return { id = nil, result = true }
-            end,
-            ["eslint/confirmESLintExecution"] = function()
-                -- VSCode language servers have a policy to request explicit approval
-                -- before applying code changes. We just approve it immediately.
-                return ConfirmExecutionResult.approved
-            end,
-            ["eslint/probeFailed"] = function()
-                notify("ESLint probe failed.", vim.log.levels.ERROR)
-                return { id = nil, result = true }
-            end,
-            ["eslint/noLibrary"] = function()
-                notify("Unable to find ESLint library.", vim.log.levels.ERROR)
-                return { id = nil, result = true }
-            end,
-            ["eslint/noConfig"] = function()
-                notify("Unable to find ESLint configuration.", vim.log.levels.ERROR)
-                return { id = nil, result = true }
-            end,
+                }
+            end
+        end,
+        default_options = {
+            cmd = { "node", path.concat { root_dir, "server", "out", "eslintServer.js" }, "--stdio" },
+            handlers = {
+                ["eslint/openDoc"] = function(_, _, open_doc)
+                    os.execute(string.format("open %q", open_doc.url))
+                    return { id = nil, result = true }
+                end,
+                ["eslint/confirmESLintExecution"] = function()
+                    -- VSCode language servers have a policy to request explicit approval
+                    -- before applying code changes. We just approve it immediately.
+                    return ConfirmExecutionResult.approved
+                end,
+                ["eslint/probeFailed"] = function()
+                    notify("ESLint probe failed.", vim.log.levels.ERROR)
+                    return { id = nil, result = true }
+                end,
+                ["eslint/noLibrary"] = function()
+                    notify("Unable to find ESLint library.", vim.log.levels.ERROR)
+                    return { id = nil, result = true }
+                end,
+                ["eslint/noConfig"] = function()
+                    notify("Unable to find ESLint configuration.", vim.log.levels.ERROR)
+                    return { id = nil, result = true }
+                end,
+            },
         },
-    },
-}
+    }
+end

--- a/lua/nvim-lsp-installer/servers/fortls/init.lua
+++ b/lua/nvim-lsp-installer/servers/fortls/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local pip3 = require "nvim-lsp-installer.installers.pip3"
 
-local root_dir = server.get_server_root_path "fortls"
-
-return server.Server:new {
-    name = "fortls",
-    root_dir = root_dir,
-    installer = pip3.packages { "fortran-language-server" },
-    default_options = {
-        cmd = { pip3.executable(root_dir, "fortls") },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = pip3.packages { "fortran-language-server" },
+        default_options = {
+            cmd = { pip3.executable(root_dir, "fortls") },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/gopls/init.lua
+++ b/lua/nvim-lsp-installer/servers/gopls/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local go = require "nvim-lsp-installer.installers.go"
 
-local root_dir = server.get_server_root_path "go"
-
-return server.Server:new {
-    name = "gopls",
-    root_dir = root_dir,
-    installer = go.packages { "golang.org/x/tools/gopls@latest" },
-    default_options = {
-        cmd = { go.executable(root_dir, "gopls") },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = go.packages { "golang.org/x/tools/gopls@latest" },
+        default_options = {
+            cmd = { go.executable(root_dir, "gopls") },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/graphql/init.lua
+++ b/lua/nvim-lsp-installer/servers/graphql/init.lua
@@ -1,33 +1,14 @@
-local util = require "lspconfig.util"
-
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "graphql"
-
-return server.Server:new {
-    name = "graphql",
-    root_dir = root_dir,
-    installer = npm.packages { "graphql-language-service-cli@latest", "graphql" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "graphql-lsp"), "server", "-m", "stream" },
-        filetypes = { "typescriptreact", "javascriptreact", "graphql" },
-        root_dir = util.root_pattern(
-            -- Sourced from https://graphql-config.com/usage/ and https://git.io/Js2dt
-            "package.json",
-            "graphql.config.json",
-            "graphql.config.js",
-            "graphql.config.ts",
-            "graphql.config.toml",
-            "graphql.config.yaml",
-            "graphql.config.yml",
-            ".graphqlrc",
-            ".graphqlrc.json",
-            ".graphqlrc.toml",
-            ".graphqlrc.yaml",
-            ".graphqlrc.yml",
-            ".graphqlrc.js",
-            ".graphqlrc.ts"
-        ),
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "graphql-language-service-cli@latest", "graphql" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "graphql-lsp"), "server", "-m", "stream" },
+            filetypes = { "typescriptreact", "javascriptreact", "graphql" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/groovyls/init.lua
+++ b/lua/nvim-lsp-installer/servers/groovyls/init.lua
@@ -2,19 +2,19 @@ local server = require "nvim-lsp-installer.server"
 local path = require "nvim-lsp-installer.path"
 local std = require "nvim-lsp-installer.installers.std"
 
-local root_dir = server.get_server_root_path "groovyls"
-
-return server.Server:new {
-    name = "groovyls",
-    root_dir = root_dir,
-    installer = {
-        std.ensure_executables { "javac" },
-        std.git_clone "https://github.com/GroovyLanguageServer/groovy-language-server",
-        std.gradlew {
-            args = { "build" },
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = {
+            std.ensure_executables { { "javac", "javac was not found in path." } },
+            std.git_clone "https://github.com/GroovyLanguageServer/groovy-language-server",
+            std.gradlew {
+                args = { "build" },
+            },
         },
-    },
-    default_options = {
-        cmd = { "java", "-jar", path.concat { root_dir, "build", "libs", "groovyls-all.jar" } },
-    },
-}
+        default_options = {
+            cmd = { "java", "-jar", path.concat { root_dir, "build", "libs", "groovyls-all.jar" } },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/hls/init.lua
+++ b/lua/nvim-lsp-installer/servers/hls/init.lua
@@ -1,37 +1,37 @@
 local server = require "nvim-lsp-installer.server"
 local platform = require "nvim-lsp-installer.platform"
-local installers = require "nvim-lsp-installer.installers"
 local path = require "nvim-lsp-installer.path"
+local installers = require "nvim-lsp-installer.installers"
 local std = require "nvim-lsp-installer.installers.std"
 local shell = require "nvim-lsp-installer.installers.shell"
 local Data = require "nvim-lsp-installer.data"
-
-local root_dir = server.get_server_root_path "haskell"
 
 local VERSION = "1.3.0"
 
 local target = Data.coalesce(
     Data.when(platform.is_mac, "haskell-language-server-macOS-%s.tar.gz"),
-    Data.when(platform.is_unix, "haskell-language-server-Linux-%s.tar.gz"),
+    Data.when(platform.is_linux, "haskell-language-server-Linux-%s.tar.gz"),
     Data.when(platform.is_win, "haskell-language-server-Windows-%s.tar.gz")
 ):format(VERSION)
 
-return server.Server:new {
-    name = "hls",
-    root_dir = root_dir,
-    installer = {
-        std.untargz_remote(
-            ("https://github.com/haskell/haskell-language-server/releases/download/%s/%s"):format(VERSION, target)
-        ),
-        installers.on {
-            -- we can't use std.chmod because of shell wildcard expansion
-            unix = shell.bash [[ chmod +x haskell*]],
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = {
+            std.untargz_remote(
+                ("https://github.com/haskell/haskell-language-server/releases/download/%s/%s"):format(VERSION, target)
+            ),
+            installers.on {
+                -- we can't use std.chmod because of shell wildcard expansion
+                unix = shell.bash [[ chmod +x haskell*]],
+            },
         },
-    },
-    default_options = {
-        cmd = { path.concat { root_dir, "haskell-language-server-wrapper", "--lsp" } },
-        cmd_env = {
-            PATH = table.concat({ root_dir, vim.env.PATH }, platform.path_sep),
+        default_options = {
+            cmd = { path.concat { root_dir, "haskell-language-server-wrapper", "--lsp" } },
+            cmd_env = {
+                PATH = table.concat({ root_dir, vim.env.PATH }, platform.path_sep),
+            },
         },
-    },
-}
+    }
+end

--- a/lua/nvim-lsp-installer/servers/html/init.lua
+++ b/lua/nvim-lsp-installer/servers/html/init.lua
@@ -1,3 +1,1 @@
-local create_server = require "nvim-lsp-installer.servers.vscode-langservers-extracted"
-
-return create_server("html", "vscode-html-language-server")
+return require "nvim-lsp-installer.servers.vscode-langservers-extracted" "vscode-html-language-server"

--- a/lua/nvim-lsp-installer/servers/intelephense/init.lua
+++ b/lua/nvim-lsp-installer/servers/intelephense/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "php"
-
-return server.Server:new {
-    name = "intelephense",
-    root_dir = root_dir,
-    installer = npm.packages { "intelephense" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "intelephense"), "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "intelephense" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "intelephense"), "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/jedi_language_server/init.lua
+++ b/lua/nvim-lsp-installer/servers/jedi_language_server/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local pip3 = require "nvim-lsp-installer.installers.pip3"
 
-local root_dir = server.get_server_root_path "jedi_language_server"
-
-return server.Server:new {
-    name = "jedi_language_server",
-    root_dir = root_dir,
-    installer = pip3.packages { "jedi-language-server" },
-    default_options = {
-        cmd = { pip3.executable(root_dir, "jedi-language-server") },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = pip3.packages { "jedi-language-server" },
+        default_options = {
+            cmd = { pip3.executable(root_dir, "jedi-language-server") },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/jsonls/init.lua
+++ b/lua/nvim-lsp-installer/servers/jsonls/init.lua
@@ -1,3 +1,1 @@
-local create_server = require "nvim-lsp-installer.servers.vscode-langservers-extracted"
-
-return create_server("jsonls", "vscode-json-language-server")
+return require "nvim-lsp-installer.servers.vscode-langservers-extracted" "vscode-json-language-server"

--- a/lua/nvim-lsp-installer/servers/kotlin_language_server/init.lua
+++ b/lua/nvim-lsp-installer/servers/kotlin_language_server/init.lua
@@ -1,22 +1,22 @@
 local server = require "nvim-lsp-installer.server"
-local path = require "nvim-lsp-installer.path"
 local platform = require "nvim-lsp-installer.platform"
+local path = require "nvim-lsp-installer.path"
 local std = require "nvim-lsp-installer.installers.std"
 
-local root_dir = server.get_server_root_path "kotlin"
-
-return server.Server:new {
-    name = "kotlin_language_server",
-    root_dir = root_dir,
-    installer = std.unzip_remote "https://github.com/fwcd/kotlin-language-server/releases/latest/download/server.zip",
-    default_options = {
-        cmd = {
-            path.concat {
-                root_dir,
-                "server",
-                "bin",
-                platform.is_win and "kotlin-language-server.bat" or "kotlin-language-server",
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = std.unzip_remote "https://github.com/fwcd/kotlin-language-server/releases/latest/download/server.zip",
+        default_options = {
+            cmd = {
+                path.concat {
+                    root_dir,
+                    "server",
+                    "bin",
+                    platform.is_win and "kotlin-language-server.bat" or "kotlin-language-server",
+                },
             },
         },
-    },
-}
+    }
+end

--- a/lua/nvim-lsp-installer/servers/ocamlls/init.lua
+++ b/lua/nvim-lsp-installer/servers/ocamlls/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "ocamlls"
-
-return server.Server:new {
-    name = "ocamlls",
-    root_dir = root_dir,
-    installer = npm.packages { "ocaml-language-server" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "ocaml-language-server"), "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "ocaml-language-server" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "ocaml-language-server"), "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/omnisharp/init.lua
+++ b/lua/nvim-lsp-installer/servers/omnisharp/init.lua
@@ -4,13 +4,11 @@ local path = require "nvim-lsp-installer.path"
 local Data = require "nvim-lsp-installer.data"
 local std = require "nvim-lsp-installer.installers.std"
 
-local root_dir = server.get_server_root_path "omnisharp"
-
 local VERSION = "v1.37.15"
 
 local target = Data.coalesce(
     Data.when(platform.is_mac, "omnisharp-osx.zip"),
-    Data.when(platform.is_unix and platform.arch == "x64", "omnisharp-linux-x64.zip"),
+    Data.when(platform.is_linux and platform.arch == "x64", "omnisharp-linux-x64.zip"),
     Data.when(
         platform.is_win,
         Data.coalesce(
@@ -20,23 +18,28 @@ local target = Data.coalesce(
     )
 )
 
-return server.Server:new {
-    name = "omnisharp",
-    root_dir = root_dir,
-    installer = {
-        std.unzip_remote(
-            ("https://github.com/OmniSharp/omnisharp-roslyn/releases/download/%s/%s"):format(VERSION, target),
-            "omnisharp"
-        ),
-        std.chmod("+x", { "omnisharp/run" }),
-    },
-    default_options = {
-        cmd = {
-            platform.is_win and path.concat { root_dir, "OmniSharp.exe" }
-                or path.concat { root_dir, "omnisharp", "run" },
-            "--languageserver",
-            "--hostPID",
-            tostring(vim.fn.getpid()),
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = {
+            std.unzip_remote(
+                ("https://github.com/OmniSharp/omnisharp-roslyn/releases/download/%s/%s"):format(VERSION, target),
+                "omnisharp"
+            ),
+            std.chmod("+x", { "omnisharp/run" }),
         },
-    },
-}
+        default_options = {
+            cmd = {
+                platform.is_win and path.concat { root_dir, "OmniSharp.exe" } or path.concat {
+                    root_dir,
+                    "omnisharp",
+                    "run",
+                },
+                "--languageserver",
+                "--hostPID",
+                tostring(vim.fn.getpid()),
+            },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/prismals/init.lua
+++ b/lua/nvim-lsp-installer/servers/prismals/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "prismals"
-
-return server.Server:new {
-    name = "prismals",
-    root_dir = root_dir,
-    installer = npm.packages { "@prisma/language-server" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "prisma-language-server"), "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "@prisma/language-server" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "prisma-language-server"), "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/purescriptls/init.lua
+++ b/lua/nvim-lsp-installer/servers/purescriptls/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "purescript"
-
-return server.Server:new {
-    name = "purescriptls",
-    root_dir = root_dir,
-    installer = npm.packages { "purescript-language-server" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "purescript-language-server"), "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "purescript-language-server" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "purescript-language-server"), "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/pylsp/init.lua
+++ b/lua/nvim-lsp-installer/servers/pylsp/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local pip3 = require "nvim-lsp-installer.installers.pip3"
 
-local root_dir = server.get_server_root_path "pylsp"
-
-return server.Server:new {
-    name = "pylsp",
-    root_dir = root_dir,
-    installer = pip3.packages { "python-lsp-server[all]" },
-    default_options = {
-        cmd = { pip3.executable(root_dir, "pylsp") },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = pip3.packages { "python-lsp-server[all]" },
+        default_options = {
+            cmd = { pip3.executable(root_dir, "pylsp") },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/pyright/init.lua
+++ b/lua/nvim-lsp-installer/servers/pyright/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "python"
-
-return server.Server:new {
-    name = "pyright",
-    root_dir = root_dir,
-    installer = npm.packages { "pyright" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "pyright-langserver"), "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "pyright" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "pyright-langserver"), "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/rescriptls/init.lua
+++ b/lua/nvim-lsp-installer/servers/rescriptls/init.lua
@@ -2,13 +2,13 @@ local server = require "nvim-lsp-installer.server"
 local path = require "nvim-lsp-installer.path"
 local std = require "nvim-lsp-installer.installers.std"
 
-local root_dir = server.get_server_root_path "rescriptls"
-
-return server.Server:new {
-    name = "rescriptls",
-    root_dir = root_dir,
-    installer = std.unzip_remote "https://github.com/rescript-lang/rescript-vscode/releases/download/1.1.3/rescript-vscode-1.1.3.vsix",
-    default_options = {
-        cmd = { "node", path.concat { root_dir, "extension", "server", "out", "server.js" }, "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = std.unzip_remote "https://github.com/rescript-lang/rescript-vscode/releases/download/1.1.3/rescript-vscode-1.1.3.vsix",
+        default_options = {
+            cmd = { "node", path.concat { root_dir, "extension", "server", "out", "server.js" }, "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/rome/init.lua
+++ b/lua/nvim-lsp-installer/servers/rome/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "rome"
-
-return server.Server:new {
-    name = "rome",
-    root_dir = root_dir,
-    installer = npm.packages { "rome@10.0.7-nightly.2021.7.2" }, -- https://github.com/rome/tools/pull/1409
-    default_options = {
-        cmd = { npm.executable(root_dir, "rome"), "lsp" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "rome@10.0.7-nightly.2021.7.2" }, -- https://github.com/rome/tools/pull/1409
+        default_options = {
+            cmd = { npm.executable(root_dir, "rome"), "lsp" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/rust_analyzer/init.lua
+++ b/lua/nvim-lsp-installer/servers/rust_analyzer/init.lua
@@ -4,8 +4,6 @@ local platform = require "nvim-lsp-installer.platform"
 local std = require "nvim-lsp-installer.installers.std"
 local Data = require "nvim-lsp-installer.data"
 
-local root_dir = server.get_server_root_path "rust"
-
 local VERSION = "2021-06-28"
 
 local target = Data.coalesce(
@@ -17,7 +15,7 @@ local target = Data.coalesce(
         )
     ),
     Data.when(
-        platform.is_unix,
+        platform.is_linux,
         Data.coalesce(
             Data.when(platform.arch == "arm64", "rust-analyzer-aarch64-unknown-linux-gnu.gz"),
             Data.when(platform.arch == "x64", "rust-analyzer-x86_64-unknown-linux-gnu.gz")
@@ -32,17 +30,19 @@ local target = Data.coalesce(
     )
 )
 
-return server.Server:new {
-    name = "rust_analyzer",
-    root_dir = root_dir,
-    installer = {
-        std.gunzip_remote(
-            ("https://github.com/rust-analyzer/rust-analyzer/releases/download/%s/%s"):format(VERSION, target),
-            platform.is_win and "rust-analyzer.exe" or "rust-analyzer"
-        ),
-        std.chmod("+x", { "rust-analyzer" }),
-    },
-    default_options = {
-        cmd = { path.concat { root_dir, "rust-analyzer" } },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = {
+            std.gunzip_remote(
+                ("https://github.com/rust-analyzer/rust-analyzer/releases/download/%s/%s"):format(VERSION, target),
+                platform.is_win and "rust-analyzer.exe" or "rust-analyzer"
+            ),
+            std.chmod("+x", { "rust-analyzer" }),
+        },
+        default_options = {
+            cmd = { path.concat { root_dir, "rust-analyzer" } },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/solargraph/init.lua
+++ b/lua/nvim-lsp-installer/servers/solargraph/init.lua
@@ -1,14 +1,14 @@
 local server = require "nvim-lsp-installer.server"
 local gem = require "nvim-lsp-installer.installers.gem"
 
-local root_dir = server.get_server_root_path "solargraph"
-
-return server.Server:new {
-    name = "solargraph",
-    root_dir = root_dir,
-    installer = gem.packages { "solargraph" },
-    default_options = {
-        cmd = { gem.executable(root_dir, "solargraph"), "stdio" },
-        cmd_env = gem.env(root_dir),
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = gem.packages { "solargraph" },
+        default_options = {
+            cmd = { gem.executable(root_dir, "solargraph"), "stdio" },
+            cmd_env = gem.env(root_dir),
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/sqlls/init.lua
+++ b/lua/nvim-lsp-installer/servers/sqlls/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "sqlls"
-
-return server.Server:new {
-    name = "sqlls",
-    root_dir = root_dir,
-    installer = npm.packages { "sql-language-server" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "sql-language-server") },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "sql-language-server" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "sql-language-server") },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/sqls/init.lua
+++ b/lua/nvim-lsp-installer/servers/sqls/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local go = require "nvim-lsp-installer.installers.go"
 
-local root_dir = server.get_server_root_path "sqls"
-
-return server.Server:new {
-    name = "sqls",
-    root_dir = root_dir,
-    installer = go.packages { "github.com/lighttiger2505/sqls" },
-    default_options = {
-        cmd = { go.executable(root_dir, "sqls") },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = go.packages { "github.com/lighttiger2505/sqls" },
+        default_options = {
+            cmd = { go.executable(root_dir, "sqls") },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/stylelint_lsp/init.lua
+++ b/lua/nvim-lsp-installer/servers/stylelint_lsp/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "stylelint_lsp"
-
-return server.Server:new {
-    name = "stylelint_lsp",
-    root_dir = root_dir,
-    installer = npm.packages { "stylelint-lsp" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "stylelint-lsp"), "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "stylelint-lsp" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "stylelint-lsp"), "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/sumneko_lua/init.lua
+++ b/lua/nvim-lsp-installer/servers/sumneko_lua/init.lua
@@ -4,46 +4,47 @@ local platform = require "nvim-lsp-installer.platform"
 local Data = require "nvim-lsp-installer.data"
 local std = require "nvim-lsp-installer.installers.std"
 
-local root_dir = server.get_server_root_path "sumneko_lua"
-
 local bin_dir = Data.coalesce(
     Data.when(platform.is_mac, "macOS"),
-    Data.when(platform.is_unix, "Linux"),
+    Data.when(platform.is_linux, "Linux"),
     Data.when(platform.is_win, "Windows")
 )
 
-return server.Server:new {
-    name = "sumneko_lua",
-    root_dir = root_dir,
-    installer = {
-        std.unzip_remote "https://github.com/sumneko/vscode-lua/releases/download/v2.3.6/lua-2.3.6.vsix",
-        -- see https://github.com/sumneko/vscode-lua/pull/43
-        std.chmod(
-            "+x",
-            { "extension/server/bin/macOS/lua-language-server", "extension/server/bin/Linux/lua-language-server" }
-        ),
-    },
-    default_options = {
-        cmd = {
-            path.concat { root_dir, "extension", "server", "bin", bin_dir, "lua-language-server" },
-            "-E",
-            path.concat { root_dir, "extension", "server", "main.lua" },
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = {
+            std.unzip_remote "https://github.com/sumneko/vscode-lua/releases/download/v2.3.6/lua-2.3.6.vsix",
+            -- see https://github.com/sumneko/vscode-lua/pull/43
+            std.chmod(
+                "+x",
+                { "extension/server/bin/macOS/lua-language-server", "extension/server/bin/Linux/lua-language-server" }
+            ),
         },
-        settings = {
-            Lua = {
-                diagnostics = {
-                    -- Get the language server to recognize the `vim` global
-                    globals = { "vim" },
-                },
-                workspace = {
-                    -- Make the server aware of Neovim runtime files
-                    library = {
-                        [vim.fn.expand "$VIMRUNTIME/lua"] = true,
-                        [vim.fn.expand "$VIMRUNTIME/lua/vim/lsp"] = true,
+        default_options = {
+            cmd = {
+                -- We need to provide a _full path_ to the executable (sumneko_lua uses it to determine... things)
+                path.concat { root_dir, "extension", "server", "bin", bin_dir, "lua-language-server" },
+                "-E",
+                path.concat { root_dir, "extension", "server", "main.lua" },
+            },
+            settings = {
+                Lua = {
+                    diagnostics = {
+                        -- Get the language server to recognize the `vim` global
+                        globals = { "vim" },
                     },
-                    maxPreload = 10000,
+                    workspace = {
+                        -- Make the server aware of Neovim runtime files
+                        library = {
+                            [vim.fn.expand "$VIMRUNTIME/lua"] = true,
+                            [vim.fn.expand "$VIMRUNTIME/lua/vim/lsp"] = true,
+                        },
+                        maxPreload = 10000,
+                    },
                 },
             },
         },
-    },
-}
+    }
+end

--- a/lua/nvim-lsp-installer/servers/svelte/init.lua
+++ b/lua/nvim-lsp-installer/servers/svelte/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "svelte"
-
-return server.Server:new {
-    name = "svelte",
-    root_dir = root_dir,
-    installer = npm.packages { "svelte-language-server" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "svelteserver"), "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "svelte-language-server" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "svelteserver"), "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/tailwindcss/init.lua
+++ b/lua/nvim-lsp-installer/servers/tailwindcss/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "tailwindcss_npm"
-
-return server.Server:new {
-    name = "tailwindcss",
-    root_dir = root_dir,
-    installer = npm.packages { "@tailwindcss/language-server" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "tailwindcss-language-server"), "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "@tailwindcss/language-server" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "tailwindcss-language-server"), "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/terraformls/init.lua
+++ b/lua/nvim-lsp-installer/servers/terraformls/init.lua
@@ -4,8 +4,6 @@ local platform = require "nvim-lsp-installer.platform"
 local std = require "nvim-lsp-installer.installers.std"
 local Data = require "nvim-lsp-installer.data"
 
-local root_dir = server.get_server_root_path "terraform"
-
 local VERSION = "0.21.0"
 
 local target = Data.coalesce(
@@ -17,7 +15,7 @@ local target = Data.coalesce(
         )
     ),
     Data.when(
-        platform.is_unix,
+        platform.is_linux,
         Data.coalesce(
             Data.when(platform.arch == "arm64", "terraform-ls_%s_linux_arm64.zip"),
             Data.when(platform.arch == "arm", "terraform-ls_%s_linux_arm.zip"),
@@ -27,14 +25,16 @@ local target = Data.coalesce(
     Data.when(platform.is_win, Data.coalesce(Data.when(platform.arch == "x64", "terraform-ls_%s_windows_amd64.zip")))
 ):format(VERSION)
 
-return server.Server:new {
-    name = "terraformls",
-    root_dir = root_dir,
-    installer = std.unzip_remote(
-        ("https://github.com/hashicorp/terraform-ls/releases/download/v%s/%s"):format(VERSION, target),
-        "terraform-ls"
-    ),
-    default_options = {
-        cmd = { path.concat { root_dir, "terraform-ls", "terraform-ls" }, "serve" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = std.unzip_remote(
+            ("https://github.com/hashicorp/terraform-ls/releases/download/v%s/%s"):format(VERSION, target),
+            "terraform-ls"
+        ),
+        default_options = {
+            cmd = { path.concat { root_dir, "terraform-ls", "terraform-ls" }, "serve" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/texlab/init.lua
+++ b/lua/nvim-lsp-installer/servers/texlab/init.lua
@@ -4,24 +4,27 @@ local std = require "nvim-lsp-installer.installers.std"
 local Data = require "nvim-lsp-installer.data"
 local platform = require "nvim-lsp-installer.platform"
 
-local root_dir = server.get_server_root_path "latex"
-
 local VERSION = "v3.2.0"
 
 local target = Data.coalesce(
     Data.when(platform.is_mac, "texlab-x86_64-macos.tar.gz"),
-    Data.when(platform.is_unix, "texlab-x86_64-linux.tar.gz"),
+    Data.when(platform.is_linux, "texlab-x86_64-linux.tar.gz"),
     Data.when(platform.is_win, "texlab-x86_64-windows.tar.gz")
 )
 
-return server.Server:new {
-    name = "texlab",
-    root_dir = root_dir,
-    installer = {
-        std.ensure_executables { "pdflatex" },
-        std.untargz_remote(("https://github.com/latex-lsp/texlab/releases/download/%s/%s"):format(VERSION, target)),
-    },
-    default_options = {
-        cmd = { path.concat { root_dir, "texlab" } },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = {
+            std.ensure_executables {
+                { "pdflatex" },
+                "A TeX distribution is not installed. Refer to https://www.latex-project.org/get/.",
+            },
+            std.untargz_remote(("https://github.com/latex-lsp/texlab/releases/download/%s/%s"):format(VERSION, target)),
+        },
+        default_options = {
+            cmd = { path.concat { root_dir, "texlab" } },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/tflint/init.lua
+++ b/lua/nvim-lsp-installer/servers/tflint/init.lua
@@ -5,44 +5,47 @@ local installers = require "nvim-lsp-installer.installers"
 local shell = require "nvim-lsp-installer.installers.shell"
 local process = require "nvim-lsp-installer.process"
 
-local root_dir = server.get_server_root_path "tflint"
+return function(name, root_dir)
+    local bin_path = path.concat { root_dir, "tflint" }
 
-local bin_path = path.concat { root_dir, "tflint" }
-
-return server.Server:new {
-    name = "tflint",
-    root_dir = root_dir,
-    installer = installers.when {
-        unix = shell.remote_bash("https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh", {
-            env = {
-                TFLINT_INSTALL_PATH = root_dir,
-                TFLINT_INSTALL_NO_ROOT = 1,
-            },
-        }),
-    },
-    default_options = {
-        cmd = { bin_path, "--langserver" },
-    },
-    post_setup = function()
-        function _G.lsp_installer_tflint_init()
-            notify "Installing TFLint plugins…"
-            process.spawn(
-                bin_path,
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = installers.when {
+            unix = shell.remote_bash(
+                "https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh",
                 {
-                    args = { "--init" },
-                    cwd = path.cwd(),
-                    stdio_sink = process.simple_sink(),
-                },
-                vim.schedule_wrap(function(success)
-                    if success then
-                        notify "Successfully installed TFLint plugins."
-                    else
-                        notify "Failed to install TFLint."
-                    end
-                end)
-            )
-        end
+                    env = {
+                        TFLINT_INSTALL_PATH = root_dir,
+                        TFLINT_INSTALL_NO_ROOT = 1,
+                    },
+                }
+            ),
+        },
+        default_options = {
+            cmd = { bin_path, "--langserver" },
+        },
+        post_setup = function()
+            function _G.lsp_installer_tflint_init()
+                notify "Installing TFLint plugins…"
+                process.spawn(
+                    bin_path,
+                    {
+                        args = { "--init" },
+                        cwd = path.cwd(),
+                        stdio_sink = process.simple_sink(),
+                    },
+                    vim.schedule_wrap(function(success)
+                        if success then
+                            notify "Successfully installed TFLint plugins."
+                        else
+                            notify "Failed to install TFLint."
+                        end
+                    end)
+                )
+            end
 
-        vim.cmd [[ command! TFLintInit call v:lua.lsp_installer_tflint_init() ]]
-    end,
-}
+            vim.cmd [[ command! TFLintInit call v:lua.lsp_installer_tflint_init() ]]
+        end,
+    }
+end

--- a/lua/nvim-lsp-installer/servers/tsserver/init.lua
+++ b/lua/nvim-lsp-installer/servers/tsserver/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "tsserver"
-
-return server.Server:new {
-    name = "tsserver",
-    root_dir = root_dir,
-    installer = npm.packages { "typescript", "typescript-language-server" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "typescript-language-server"), "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "typescript", "typescript-language-server" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "typescript-language-server"), "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/vimls/init.lua
+++ b/lua/nvim-lsp-installer/servers/vimls/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "vim"
-
-return server.Server:new {
-    name = "vimls",
-    root_dir = root_dir,
-    installer = npm.packages { "vim-language-server@latest" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "vim-language-server"), "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "vim-language-server@latest" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "vim-language-server"), "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/vscode-langservers-extracted/init.lua
+++ b/lua/nvim-lsp-installer/servers/vscode-langservers-extracted/init.lua
@@ -1,18 +1,15 @@
 local server = require "nvim-lsp-installer.server"
-local opts = require "nvim-lsp-installer.opts"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "vscode-langservers-extracted"
-
-return function(name, executable)
-    local resolved_root_dir = opts.allow_federated_servers() and root_dir or ("%s_%s"):format(root_dir, name)
-
-    return server.Server:new {
-        name = name,
-        root_dir = resolved_root_dir,
-        installer = npm.packages { "vscode-langservers-extracted" },
-        default_options = {
-            cmd = { npm.executable(resolved_root_dir, executable), "--stdio" },
-        },
-    }
+return function(executable)
+    return function(name, root_dir)
+        return server.Server:new {
+            name = name,
+            root_dir = root_dir,
+            installer = npm.packages { "vscode-langservers-extracted" },
+            default_options = {
+                cmd = { npm.executable(root_dir, executable) },
+            },
+        }
+    end
 end

--- a/lua/nvim-lsp-installer/servers/vuels/init.lua
+++ b/lua/nvim-lsp-installer/servers/vuels/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "vuels"
-
-return server.Server:new {
-    name = "vuels",
-    root_dir = root_dir,
-    installer = npm.packages { "vls" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "vls"), "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "vls" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "vls"), "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/servers/yamlls/init.lua
+++ b/lua/nvim-lsp-installer/servers/yamlls/init.lua
@@ -1,13 +1,13 @@
 local server = require "nvim-lsp-installer.server"
 local npm = require "nvim-lsp-installer.installers.npm"
 
-local root_dir = server.get_server_root_path "yaml"
-
-return server.Server:new {
-    name = "yamlls",
-    root_dir = root_dir,
-    installer = npm.packages { "yaml-language-server" },
-    default_options = {
-        cmd = { npm.executable(root_dir, "yaml-language-server"), "--stdio" },
-    },
-}
+return function(name, root_dir)
+    return server.Server:new {
+        name = name,
+        root_dir = root_dir,
+        installer = npm.packages { "yaml-language-server" },
+        default_options = {
+            cmd = { npm.executable(root_dir, "yaml-language-server"), "--stdio" },
+        },
+    }
+end

--- a/lua/nvim-lsp-installer/ui/display.lua
+++ b/lua/nvim-lsp-installer/ui/display.lua
@@ -1,5 +1,6 @@
 local Ui = require "nvim-lsp-installer.ui"
 local log = require "nvim-lsp-installer.log"
+local process = require "nvim-lsp-installer.process"
 local state = require "nvim-lsp-installer.ui.state"
 
 local M = {}
@@ -10,22 +11,6 @@ function _G.lsp_install_redraw(winnr)
     local fn = redraw_by_winnr[winnr]
     if fn then
         fn()
-    end
-end
-
-local function debounced(debounced_fn)
-    local queued = false
-    local last_arg = nil
-    return function(a)
-        last_arg = a
-        if queued then
-            return
-        end
-        queued = true
-        vim.schedule(function()
-            debounced_fn(last_arg)
-            queued = false
-        end)
     end
 end
 
@@ -161,7 +146,7 @@ function M.new_view_only_win(name)
         return win
     end
 
-    local draw = debounced(function(view)
+    local draw = process.debounced(function(view)
         local win = vim.fn.win_findbuf(buf)[1]
         if not win or not vim.api.nvim_buf_is_valid(buf) then
             -- the window has been closed or the buffer is somehow no longer valid


### PR DESCRIPTION
So I've done some work to defer require calls as much as possible. These are by far the biggest culprits in terms of performance. On my Windows machine a single require took ~5ms (multiply that for each available server...). The problem today is that all the metadata for a given server exist exclusively inside each server's Lua module - which forces us to require all servers to do things like identify which ones are installed etc. I've started separating this a bit and colocating all the essential metadata in one location, and deferring all the "ad-hoc" metadata to the server modules themselves. This allows us to very quickly identify which servers are installed by scanning the root install directory once (via libuv), and then only require the installed servers.

The important metric is what's called when a user registers a on_server_ready callback, because that's the first touchpoint. Here are some profiling results I did across 3 different machines and operating systems:

```
macOS (11 servers installed)
37ms -> 10ms (~73% faster)

macOS (1 server installed)
37ms -> 1ms (~97% faster)

Windows (11 servers installed)
230ms -> 48ms (~80% faster)

Windows (0 servers installed)
230ms -> 0ms (∞% faster)

Low-end Ubuntu machine (11 servers installed)
80ms -> 24ms (~70% faster)
```