### PR TITLE
fix: Add `--stdio` to the argument of vscode-langservers-extracted

### DIFF
--- a/lua/nvim-lsp-installer/servers/vscode-langservers-extracted/init.lua
+++ b/lua/nvim-lsp-installer/servers/vscode-langservers-extracted/init.lua
@@ -8,7 +8,7 @@ return function(executable)
             root_dir = root_dir,
             installer = npm.packages { "vscode-langservers-extracted" },
             default_options = {
-                cmd = { npm.executable(root_dir, executable), '--stdio' },
+                cmd = { npm.executable(root_dir, executable), "--stdio" },
             },
         }
     end

--- a/lua/nvim-lsp-installer/servers/vscode-langservers-extracted/init.lua
+++ b/lua/nvim-lsp-installer/servers/vscode-langservers-extracted/init.lua
@@ -8,7 +8,7 @@ return function(executable)
             root_dir = root_dir,
             installer = npm.packages { "vscode-langservers-extracted" },
             default_options = {
-                cmd = { npm.executable(root_dir, executable) },
+                cmd = { npm.executable(root_dir, executable), '--stdio' },
             },
         }
     end


### PR DESCRIPTION
In my environment, it did not start properly without --stdio, so I added the argument.