### PR TITLE
Update the go.lua script for the new golang install deprecation

### DIFF
--- a/lua/nvim-lsp-installer/installers/go.lua
+++ b/lua/nvim-lsp-installer/installers/go.lua
@@ -26,7 +26,7 @@ function M.packages(packages)
                 pkgs[1] = ("%s@%s"):format(pkgs[1], context.requested_server_version)
             end
 
-            c.run("go", vim.list_extend({ "get", "-v" }, pkgs))
+            c.run("go", vim.list_extend({ "install"}, pkgs))
             c.run("go", { "clean", "-modcache" })
 
             c.spawn(callback)


### PR DESCRIPTION
Hi 😃 

I found this install with the old `go get` command binaries with the new version of go this is deprecated

For more information check [here](https://golang.org/doc/go-get-install-deprecation)