### PR TITLE
fix: omnisharp installation path

### DIFF
--- a/lua/nvim-lsp-installer/servers/omnisharp/init.lua
+++ b/lua/nvim-lsp-installer/servers/omnisharp/init.lua
@@ -33,7 +33,7 @@ return function(name, root_dir)
         },
         default_options = {
             cmd = {
-                platform.is_win and path.concat { root_dir, "OmniSharp.exe" } or path.concat {
+                platform.is_win and path.concat { root_dir, "omnisharp", "OmniSharp.exe" } or path.concat {
                     root_dir,
                     "omnisharp",
                     "run",


### PR DESCRIPTION
Currently this plugin is installing the Omnisharp executable on the path "%AppData%\Local\nvim-data\lsp_servers\omnisharp\omnisharp" but trying to execute it as it was on "%AppData%\Local\nvim-data\lsp_servers\omnisharp" (one level shallower).

The installation path:
![image](https://user-images.githubusercontent.com/25470308/136465150-210b9ae6-114e-4379-8aac-1be3ba70188e.png)