### PR TITLE
Eslint doc for how to resolve eslint in yarn2 repo's

### DIFF
--- a/lua/nvim-lsp-installer/servers/eslint/README.md
+++ b/lua/nvim-lsp-installer/servers/eslint/README.md
@@ -36,3 +36,23 @@ This will make `eslint` respond to formatting requests, for example when trigger
 -   `:lua vim.lsp.buf.formatting()`
 -   `:lua vim.lsp.buf.formatting_seq_sync()`
 -   `:lua vim.lsp.buf.formatting_sync()`
+
+## Eslint in projects that use pnp
+
+To allow the `eslint` server to resolve eslint and eslint plugins in a project that uses yarn 2/pnp, you need to manually change the
+command used to run the server. This is done when setting up the LSP server, like so:
+
+```lua
+lsp_installer.on_server_ready(function (server)
+    local opts = {
+        on_attach = common_on_attach,
+    }
+
+    if server.name == "eslint" then
+      local default_opts = server:get_default_options()
+      opts.cmd = vim.list_extend({"yarn", "node"}, default_opts.cmd)
+    end
+
+    server:setup(opts)
+end)
+```


### PR DESCRIPTION
This solves the problem resolving eslint in yarn 2 repositories for use with the eslint lsp.

__NOTE__: I feel there is probably a nicer way to do this but this atleast works