### PR TITLE
Remove the pdflatex check for texlab installation

### DIFF
--- a/lua/nvim-lsp-installer/servers/texlab/init.lua
+++ b/lua/nvim-lsp-installer/servers/texlab/init.lua
@@ -13,9 +13,6 @@ return function(name, root_dir)
         root_dir = root_dir,
         homepage = "https://github.com/latex-lsp/texlab",
         installer = {
-            std.ensure_executables {
-                { "pdflatex", "A TeX distribution is not installed. Refer to https://www.latex-project.org/get/." },
-            },
             context.use_github_release_file(
                 "latex-lsp/texlab",
                 coalesce(


### PR DESCRIPTION
Texlab can work with other engines such as `tectonic`, unless you want to check for all compatible latex engines we should remove this check

Closes #172