### PR TITLE
Fix the path for denols

### DIFF
--- a/lua/nvim-lsp-installer/servers/denols/init.lua
+++ b/lua/nvim-lsp-installer/servers/denols/init.lua
@@ -32,7 +32,7 @@ return function(name, root_dir)
             end),
         },
         default_options = {
-            cmd = { path.concat { root_dir, "bin", "deno" }, "lsp" },
+            cmd = { path.concat { root_dir, "deno" }, "lsp" },
         },
     }
 end


### PR DESCRIPTION
The deno binary is installed directly in lsp_servers/denols, not in a bin subdirectory.

Fixes #178 