### PR TITLE
Add potential fix for #156

### DIFF
--- a/lua/nvim-lsp-installer/servers/jdtls/init.lua
+++ b/lua/nvim-lsp-installer/servers/jdtls/init.lua
@@ -26,7 +26,7 @@ return function(name, root_dir)
                 Data.coalesce(
                     Data.when(platform.is_mac, "config_mac"),
                     Data.when(platform.is_linux, "config_linux"),
-                    Data.when(platform.is_win, "config_windows")
+                    Data.when(platform.is_win, "config_win")
                 ),
             },
             "-data",


### PR DESCRIPTION
I had the same issue as #156.
Since I had set up jdtls manually on windows before, I compared my previous config, and it seems the directory for the windows config is just named wrong. See the [readme of jdtls](https://github.com/eclipse/eclipse.jdt.ls)

This fix works for me so far. I only tested on my one windows dev machine I have though, and I don't really do much Java, so it might be a fluke.
I will set up a fresh windows VM tomorrow and install everything from scratch and see if that still works.
In the meantime, someone else testing this pull would be much appreciated.