### PR TITLE
fix: use schedule_wrap for on_server_ready

### DIFF
--- a/lua/nvim-lsp-installer.lua
+++ b/lua/nvim-lsp-installer.lua
@@ -118,6 +118,7 @@ end
 --- Use the .on_server_ready(cb) function to register a handler to be executed when a server is ready to be set up.
 ---@param server_identifier string @The server to install. This can also include a requested version, for example "rust_analyzer@nightly".
 function M.install(server_identifier)
+    log.fmt_debug("Received request to install server %s.", server_identifier)
     local server_name, version = servers.parse_server_identifier(server_identifier)
     local ok, server = servers.get_server(server_name)
     if not ok then
@@ -179,9 +180,11 @@ end
 
 ---@param cb fun(server: Server) @Callback to be executed whenever a server is ready to be set up.
 function M.on_server_ready(cb)
+    log.debug "Received on_server_ready"
     dispatcher.register_server_ready_callback(cb)
-    vim.schedule(function()
+    vim.schedule_wrap(function()
         local installed_servers = servers.get_installed_servers()
+        log.fmt_debug("Running on_server_ready for [%s] server(s)", #installed_servers)
         for i = 1, #installed_servers do
             dispatcher.dispatch_server_ready(installed_servers[i])
         end

--- a/lua/nvim-lsp-installer/dispatcher.lua
+++ b/lua/nvim-lsp-installer/dispatcher.lua
@@ -1,4 +1,5 @@
 local notify = require "nvim-lsp-installer.notify"
+local log = require "nvim-lsp-installer.log"
 
 local M = {}
 
@@ -7,6 +8,7 @@ local registered_callbacks = {}
 M.dispatch_server_ready = function(server)
     for _, callback in pairs(registered_callbacks) do
         local ok, err = pcall(callback, server)
+        log.fmt_debug("running on_server_ready for [%s]", server.name)
         if not ok then
             notify(tostring(err), vim.log.levels.ERROR)
         end

--- a/lua/nvim-lsp-installer/server.lua
+++ b/lua/nvim-lsp-installer/server.lua
@@ -102,6 +102,7 @@ end
 
 ---Queues the server to be asynchronously installed.
 function M.Server:install()
+    log.fmt_debug("Received request to install server %s.", self.name)
     status_win().install_server(self)
 end
 


### PR DESCRIPTION
# Description
Use the safer `schedule_wrap` which works correctly when setup called is invoked from ftplugin.

~~Fixes #216~~ That issue was fixed in #199, but `schedule_wrap` still seems like the better choice here.

## How has this been tested

I chose `jdtls` because I wanted a server with slower installation. Add the following to `java.lua`

<details>
<summary>Click to expand</summary>

```lua
local installer = require("nvim-lsp-installer")
local servers = require("nvim-lsp-installer.servers")
local log = require("nvim-lsp-installer.log")

local server_name = "jdtls"
local config = {}

local install_notification = false

local server_available, requested_server = servers.get_server(server_name)

-- until server:on_ready() fn exists upstream
function requested_server:on_ready(cb)
	installer.on_server_ready(function(server)
		if server.name == server_name then
			cb()
		end
	end)
end

if server_available then
	if not requested_server:is_installed() then
		install_notification = true
		log.debug("Automatic server installation detected")
		vim.notify("Automatic server installation detected", vim.log.levels.INFO)
		requested_server:install()
	end
end

requested_server:on_ready(function()
	requested_server:setup(config)
	if install_notification then
		log.debug(string.format("Installation complete for [%s] server", requested_server.name))
		vim.notify(string.format("Installation complete for [%s] server", requested_server.name), vim.log.levels.INFO)
		install_notification = false
	end
end)
```

</details>

The "Installation complete" notice ~~now~~ still appears correctly after the installation is actually done.

https://user-images.githubusercontent.com/59826753/139530162-eae10ad7-066d-41ad-9f82-e53ce3fe4b1f.mp4



