### PR TITLE
Add lombok support #205

### DIFF
--- a/lua/nvim-lsp-installer/servers/jdtls/init.lua
+++ b/lua/nvim-lsp-installer/servers/jdtls/init.lua
@@ -20,10 +20,9 @@ return function(name, root_dir)
             "-Dlog.level=ALL",
             "-Xms1g",
             "-Xmx2G",
+            "-javaagent:" .. lombok,
             "-jar",
             jar,
-            "-javaagent:" .. lombok,
-            "-Xbootclasspath/a:" .. lombok,
             "-configuration",
             path.concat {
                 root_dir,

--- a/lua/nvim-lsp-installer/servers/jdtls/init.lua
+++ b/lua/nvim-lsp-installer/servers/jdtls/init.lua
@@ -9,6 +9,8 @@ return function(name, root_dir)
     local function get_cmd(workspace_name)
         local executable = vim.env.JAVA_HOME and path.concat { vim.env.JAVA_HOME, "bin", "java" } or "java"
         local jar = vim.fn.expand(path.concat { root_dir, "plugins", "org.eclipse.equinox.launcher_*.jar" })
+        local lombok = vim.fn.expand(path.concat { root_dir, "lombok.jar" })
+
         return {
             platform.is_win and ("%s.exe"):format(executable) or executable,
             "-Declipse.application=org.eclipse.jdt.ls.core.id1",
@@ -20,6 +22,8 @@ return function(name, root_dir)
             "-Xmx2G",
             "-jar",
             jar,
+            "-javaagent:" .. lombok,
+            "-Xbootclasspath/a:" .. lombok,
             "-configuration",
             path.concat {
                 root_dir,


### PR DESCRIPTION
At the moment lombok is downloaded to the LS directory but never used. This loads the plugin when loading the `jdtls`.