### PR TITLE
introduce an Installer class to allow associating metadata with each installer

### DIFF
--- a/lua/nvim-lsp-installer/installers/init.lua
+++ b/lua/nvim-lsp-installer/installers/init.lua
@@ -173,20 +173,29 @@ end
 M.Installer = {}
 M.Installer.__index = M.Installer
 
-function M.Installer:__call(...)
-    return self.installer(...)
-end
-
 ---@param installer ServerInstallerFunction
 ---@param meta InstallerMeta | nil @The metadata to associate with the installer.
-function M.meta(installer, meta)
-    meta = meta or {
+function M.Installer:new(installer, meta)
+    meta = vim.tbl_deep_extend("force", {
         use_tmp_dir = true,
-    }
+    }, meta or {})
+
     return setmetatable({
         installer = installer,
         meta = meta,
     }, M.Installer)
+end
+
+function M.Installer:__call(...)
+    return self.installer(...)
+end
+
+---Shorthand for the Installer constructor.
+---@param installer ServerInstallerFunction
+---@param meta InstallerMeta | nil @The metadata to associate with the installer.
+---@return Installer
+function M.meta(installer, meta)
+    return M.Installer:new(installer, meta)
 end
 
 return M

--- a/lua/nvim-lsp-installer/installers/pip3.lua
+++ b/lua/nvim-lsp-installer/installers/pip3.lua
@@ -47,7 +47,12 @@ end
 function M.packages(packages)
     local py3 = create_installer("python3", packages)
     local py = create_installer("python", packages)
-    return installers.first_successful(platform.is_win and { py, py3 } or { py3, py }) -- see https://github.com/williamboman/nvim-lsp-installer/issues/128
+    return installers.meta(
+        installers.first_successful(platform.is_win and { py, py3 } or { py3, py }), -- see https://github.com/williamboman/nvim-lsp-installer/issues/128
+        {
+            use_tmp_dir = false,
+        }
+    )
 end
 
 ---@param root_dir string @The directory to resolve the executable from.

--- a/lua/nvim-lsp-installer/ui/status-win/init.lua
+++ b/lua/nvim-lsp-installer/ui/status-win/init.lua
@@ -544,7 +544,7 @@ local function init(all_servers)
             state.servers[server.name].installer.is_running = true
         end)
 
-        log.fmt_info("Starting install server_name=%s, requested_version=%s", server.name, requested_version or "N/A")
+        log.fmt_info("Starting install server_name=%s, requested_version=%s", server.name, requested_version or "")
 
         server:install_attached({
             requested_server_version = requested_version,
@@ -609,7 +609,7 @@ local function init(all_servers)
     ---@param server Server
     ---@param version string|nil
     local function install_server(server, version)
-        log.debug("Installing server", server, version)
+        log.fmt_debug("Queuing server=%s, version=%s for installation", server.name, version or "")
         local server_state = get_state().servers[server.name]
         if server_state and (server_state.installer.is_running or server_state.installer.is_queued) then
             log.debug("Installer is already queued/running", server.name)


### PR DESCRIPTION
This will allow individual installer functions to attach contextual metadata
to it. This will enable more in-depth information and analysis of what will be
executed which can be leveraged in different ways (e.g., display the series of
actions that will be executed when installing a server, prior to installing
it).

It can also allow installers to control how they're executed, for example
whether a tmpdir should be used or not. This is the main motivation of
introducing it.

Fixes #223.