### PR TITLE
pip3: promote install_dir to server's root dir immediately

### DIFF
--- a/lua/nvim-lsp-installer/installers/context.lua
+++ b/lua/nvim-lsp-installer/installers/context.lua
@@ -123,6 +123,22 @@ function M.use_github_release_file(repo, file)
     }
 end
 
+---Creates an installer that moves the current installation directory to the server's root directory.
+function M.promote_install_dir()
+    ---@type ServerInstallerFunction
+    return function(server, callback, context)
+        if server:promote_install_dir(context.install_dir) then
+            context.install_dir = server.root_dir
+            callback(true)
+        else
+            context.stdio_sink.stderr(
+                ("Failed to promote temporary install directory to %s.\n"):format(server.root_dir)
+            )
+            callback(false)
+        end
+    end
+end
+
 ---Access the context ojbect to create a new installer.
 ---@param fn fun(context: ServerInstallContext): ServerInstallerFunction
 function M.capture(fn)

--- a/lua/nvim-lsp-installer/installers/init.lua
+++ b/lua/nvim-lsp-installer/installers/init.lua
@@ -97,7 +97,7 @@ function M.always_succeed(installer)
 end
 
 ---@param platform_table table<Platform, ServerInstallerFunction>
----@return ServerInstallerFunction | nil
+---@return ServerInstallerFunction | ServerInstallerFunction[] | nil
 local function get_by_platform(platform_table)
     if platform.is_mac then
         return platform_table.mac or platform_table.unix
@@ -133,7 +133,7 @@ end
 
 --- Creates a server installer that executes the given installer for the current platform.
 --- If there is no server installer provided for the current platform, the installer will instantly exit with a failure.
----@param platform_table table<Platform, ServerInstallerFunction>
+---@param platform_table table<Platform, ServerInstallerFunction|ServerInstallerFunction[]>
 ---@return ServerInstallerFunction
 function M.when(platform_table)
     return function(server, callback, context)

--- a/lua/nvim-lsp-installer/installers/pip3.lua
+++ b/lua/nvim-lsp-installer/installers/pip3.lua
@@ -5,6 +5,7 @@ local std = require "nvim-lsp-installer.installers.std"
 local platform = require "nvim-lsp-installer.platform"
 local process = require "nvim-lsp-installer.process"
 local settings = require "nvim-lsp-installer.settings"
+local context = require "nvim-lsp-installer.installers.context"
 
 local M = {}
 
@@ -47,7 +48,10 @@ end
 function M.packages(packages)
     local py3 = create_installer("python3", packages)
     local py = create_installer("python", packages)
-    return installers.first_successful(platform.is_win and { py, py3 } or { py3, py }) -- see https://github.com/williamboman/nvim-lsp-installer/issues/128
+    return installers.pipe {
+        context.promote_install_dir(),
+        installers.first_successful(platform.is_win and { py, py3 } or { py3, py }), -- see https://github.com/williamboman/nvim-lsp-installer/issues/128
+    }
 end
 
 ---@param root_dir string @The directory to resolve the executable from.

--- a/lua/nvim-lsp-installer/server.lua
+++ b/lua/nvim-lsp-installer/server.lua
@@ -136,6 +136,38 @@ function M.Server:_setup_install_context(context)
     end
 end
 
+---Removes any existing installation of the server, and moves/promotes the provided install_dir directory to its place.
+---@param install_dir string @The installation directory to move to the server's root directory.
+function M.Server:promote_install_dir(install_dir)
+    if self.root_dir == install_dir then
+        log.fmt_debug("Install dir %s is already promoted for %s", install_dir, self.name)
+        return true
+    end
+    log.fmt_debug("Promoting installation directory %s for %s", install_dir, self.name)
+    -- 1. Remove final installation directory, if it exists
+    if fs.dir_exists(self.root_dir) then
+        local rmrf_ok, rmrf_err = pcall(fs.rmrf, self.root_dir)
+        if not rmrf_ok then
+            log.fmt_error("Failed to remove final installation directory. path=%s error=%s", self.root_dir, rmrf_err)
+            return false
+        end
+    end
+
+    -- 2. Move the temporary install dir to the final installation directory
+    if platform.is_unix then
+        -- Some Unix systems will raise an error when renaming a directory to a destination that does not already exist.
+        fs.mkdir(self.root_dir)
+    end
+    local rename_ok, rename_err = pcall(fs.rename, install_dir, self.root_dir)
+    if not rename_ok then
+        --- 2a. We failed to rename the temporary dir to the final installation dir
+        log.fmt_error("Failed to rename. path=%s new_path=%s error=%s", install_dir, self.root_dir, rename_err)
+        return false
+    end
+    log.fmt_debug("Successfully promoted install_dir=%s for %s", install_dir, self.name)
+    return true
+end
+
 ---@param context ServerInstallContext
 ---@param callback ServerInstallCallback
 function M.Server:install_attached(context, callback)
@@ -150,54 +182,22 @@ function M.Server:install_attached(context, callback)
         self,
         vim.schedule_wrap(function(success)
             if success then
-                -- 1. Remove final installation directory, if it exists
-                if fs.dir_exists(self.root_dir) then
-                    local rmrf_ok, rmrf_err = pcall(fs.rmrf, self.root_dir)
-                    if not rmrf_ok then
-                        log.fmt_error(
-                            "Failed to remove final installation directory. path=%s error=%s",
-                            self.root_dir,
-                            rmrf_err
-                        )
-                        context.stdio_sink.stderr "Failed to remove final installation directory.\n"
-                        context.stdio_sink.stderr(tostring(rmrf_err) .. "\n")
-                        callback(false)
-                        return
-                    end
-                end
-
-                -- 2. Move the temporary install dir to the final installation directory
-                if platform.is_unix then
-                    -- Some Unix systems will raise an error when renaming a directory to a destination that does not
-                    -- already exist.
-                    fs.mkdir(self.root_dir)
-                end
-                local rename_ok, rename_err = pcall(fs.rename, context.install_dir, self.root_dir)
-                if rename_ok then
-                    -- 3a. Dispatch the server is ready
-                    vim.schedule(function()
-                        dispatcher.dispatch_server_ready(self)
-                        for _, on_ready_handler in ipairs(self._on_ready_handlers) do
-                            on_ready_handler(self)
-                        end
-                    end)
-                else
-                    --- 3b. We failed to rename the temporary dir to the final installation dir
-                    log.fmt_error(
-                        "Failed to rename. path=%s new_path=%s error=%s",
-                        context.install_dir,
-                        self.root_dir,
-                        rename_err
-                    )
-                    context.stdio_sink.stderr(
-                        ("Failed to rename %q to %q.\n"):format(context.install_dir, self.root_dir)
-                    )
-                    context.stdio_sink.stderr(tostring(rename_err) .. "\n")
+                if not self:promote_install_dir(context.install_dir) then
                     callback(false)
                     return
                 end
+
+                -- Dispatch the server is ready
+                vim.schedule(function()
+                    dispatcher.dispatch_server_ready(self)
+                    for _, on_ready_handler in ipairs(self._on_ready_handlers) do
+                        on_ready_handler(self)
+                    end
+                end)
+                callback(true)
+            else
+                callback(false)
             end
-            callback(success)
         end),
         context
     )

--- a/lua/nvim-lsp-installer/server.lua
+++ b/lua/nvim-lsp-installer/server.lua
@@ -183,6 +183,9 @@ function M.Server:install_attached(context, callback)
         vim.schedule_wrap(function(success)
             if success then
                 if not self:promote_install_dir(context.install_dir) then
+                    context.stdio_sink.stderr(
+                        ("Failed to promote the temporary installation directory %q.\n"):format(context.install_dir)
+                    )
                     callback(false)
                     return
                 end

--- a/lua/nvim-lsp-installer/servers/clangd/init.lua
+++ b/lua/nvim-lsp-installer/servers/clangd/init.lua
@@ -1,4 +1,3 @@
-local fs = require "nvim-lsp-installer.fs"
 local server = require "nvim-lsp-installer.server"
 local path = require "nvim-lsp-installer.path"
 local Data = require "nvim-lsp-installer.data"

--- a/lua/nvim-lsp-installer/servers/vala_ls/init.lua
+++ b/lua/nvim-lsp-installer/servers/vala_ls/init.lua
@@ -27,7 +27,7 @@ return function(name, root_dir)
             end),
             function(_, callback, ctx)
                 local c = process.chain {
-                    cwd = path.concat { cwd.install_dir, "vala-language-server" },
+                    cwd = path.concat { ctx.install_dir, "vala-language-server" },
                     stdio_sink = ctx.stdio_sink,
                 }
 

--- a/lua/nvim-lsp-installer/ui/status-win/init.lua
+++ b/lua/nvim-lsp-installer/ui/status-win/init.lua
@@ -544,7 +544,7 @@ local function init(all_servers)
             state.servers[server.name].installer.is_running = true
         end)
 
-        log.fmt_info("Starting install server_name=%s, requested_version=%s", server.name, requested_version or "N/A")
+        log.fmt_info("Starting install server_name=%s, requested_version=%s", server.name, requested_version or "")
 
         server:install_attached({
             requested_server_version = requested_version,
@@ -609,7 +609,7 @@ local function init(all_servers)
     ---@param server Server
     ---@param version string|nil
     local function install_server(server, version)
-        log.debug("Installing server", server, version)
+        log.fmt_debug("Queuing server=%s, version=%s for installation", server.name, version or "")
         local server_state = get_state().servers[server.name]
         if server_state and (server_state.installer.is_running or server_state.installer.is_queued) then
             log.debug("Installer is already queued/running", server.name)


### PR DESCRIPTION
This fixes issues with renaming py3 venv.

Fixes #223.