### PR TITLE
moved add-opens and add-modules  java options before jar option

### DIFF
--- a/lua/nvim-lsp-installer/servers/jdtls/init.lua
+++ b/lua/nvim-lsp-installer/servers/jdtls/init.lua
@@ -21,6 +21,11 @@ return function(name, root_dir)
             "-Xms1g",
             "-Xmx2G",
             "-javaagent:" .. lombok,
+            "--add-modules=ALL-SYSTEM",
+            "--add-opens",
+            "java.base/java.util=ALL-UNNAMED",
+            "--add-opens",
+            "java.base/java.lang=ALL-UNNAMED",
             "-jar",
             jar,
             "-configuration",
@@ -34,11 +39,6 @@ return function(name, root_dir)
             },
             "-data",
             workspace_name,
-            "--add-modules=ALL-SYSTEM",
-            "--add-opens",
-            "java.base/java.util=ALL-UNNAMED",
-            "--add-opens",
-            "java.base/java.lang=ALL-UNNAMED",
         }
     end
 


### PR DESCRIPTION
The issue is `--add-opens` and `--add-modules` are arguments to jvm. If we put them after the `-jar` option, they are passed to the java program, not the jvm. Similar fix was done in https://github.com/kabouzeid/nvim-lspinstall/pull/117