### PR TITLE
Get the python executable from settings instead of hard-coding it

### DIFF
--- a/lua/nvim-lsp-installer/installers/pip3.lua
+++ b/lua/nvim-lsp-installer/installers/pip3.lua
@@ -46,9 +46,13 @@ end
 
 ---@param packages string[] @The pip packages to install. The first item in this list will be the recipient of the server version, should the user request a specific one.
 function M.packages(packages)
-    local py3_host_prog = settings.current.python3_exeutable
+    local py3 = create_installer("python3", packages)
+    local py = create_installer("python", packages)
+    local py3_host_prog = vim.api.nvim_get_var "python3_host_prog"
+
     return installers.pipe {
         context.promote_install_dir(),
+        -- see https://github.com/williamboman/nvim-lsp-installer/issues/128
         installers.first_successful(platform.is_win and { py3_host_prog, py, py3 } or { py3_host_prog, py3, py }),
     }
 end

--- a/lua/nvim-lsp-installer/installers/pip3.lua
+++ b/lua/nvim-lsp-installer/installers/pip3.lua
@@ -6,6 +6,7 @@ local platform = require "nvim-lsp-installer.platform"
 local process = require "nvim-lsp-installer.process"
 local settings = require "nvim-lsp-installer.settings"
 local context = require "nvim-lsp-installer.installers.context"
+local log = require "nvim-lsp-installer.log"
 
 local M = {}
 
@@ -48,13 +49,13 @@ end
 function M.packages(packages)
     local py3 = create_installer("python3", packages)
     local py = create_installer("python", packages)
-    local py3_host_prog = vim.api.nvim_get_var "python3_host_prog"
-
     -- see https://github.com/williamboman/nvim-lsp-installer/issues/128
     local installer_variants = platform.is_win and { py, py3 } or { py3, py }
 
+    local py3_host_prog = vim.g.python3_host_prog
     if py3_host_prog then
-        table.insert(installer_variants, 1, py3_host_prog)
+        log.fmt_debug("Found python3_host_prog (%s)", py3_host_prog)
+        table.insert(installer_variants, 1, create_installer(py3_host_prog, packages))
     end
 
     return installers.pipe {

--- a/lua/nvim-lsp-installer/installers/pip3.lua
+++ b/lua/nvim-lsp-installer/installers/pip3.lua
@@ -46,9 +46,10 @@ end
 
 ---@param packages string[] @The pip packages to install. The first item in this list will be the recipient of the server version, should the user request a specific one.
 function M.packages(packages)
+    local py3_host_prog = settings.current.python3_exeutable
     return installers.pipe {
         context.promote_install_dir(),
-        create_installer(settings.current.python3_exeutable, packages),
+        installers.first_successful(platform.is_win and { py3_host_prog, py, py3 } or { py3_host_prog, py3, py }),
     }
 end
 

--- a/lua/nvim-lsp-installer/installers/pip3.lua
+++ b/lua/nvim-lsp-installer/installers/pip3.lua
@@ -50,10 +50,16 @@ function M.packages(packages)
     local py = create_installer("python", packages)
     local py3_host_prog = vim.api.nvim_get_var "python3_host_prog"
 
+    -- see https://github.com/williamboman/nvim-lsp-installer/issues/128
+    local installer_variants = platform.is_win and { py, py3 } or { py3, py }
+
+    if py3_host_prog then
+        table.insert(installer_variants, 1, py3_host_prog)
+    end
+
     return installers.pipe {
         context.promote_install_dir(),
-        -- see https://github.com/williamboman/nvim-lsp-installer/issues/128
-        installers.first_successful(platform.is_win and { py3_host_prog, py, py3 } or { py3_host_prog, py3, py }),
+        installers.first_successful(installer_variants),
     }
 end
 

--- a/lua/nvim-lsp-installer/installers/pip3.lua
+++ b/lua/nvim-lsp-installer/installers/pip3.lua
@@ -46,11 +46,9 @@ end
 
 ---@param packages string[] @The pip packages to install. The first item in this list will be the recipient of the server version, should the user request a specific one.
 function M.packages(packages)
-    local py3 = create_installer("python3", packages)
-    local py = create_installer("python", packages)
     return installers.pipe {
         context.promote_install_dir(),
-        installers.first_successful(platform.is_win and { py, py3 } or { py3, py }), -- see https://github.com/williamboman/nvim-lsp-installer/issues/128
+        create_installer(settings.current.python3_exeutable, packages),
     }
 end
 

--- a/lua/nvim-lsp-installer/settings.lua
+++ b/lua/nvim-lsp-installer/settings.lua
@@ -35,6 +35,7 @@ local DEFAULT_SETTINGS = {
         -- Example: { "--proxy", "https://proxyserver" }
         install_args = {},
     },
+    python3_exeutable = vim.api.nvim_get_var("python3_host_prog"),
 
     -- Controls to which degree logs are written to the log file. It's useful to set this to vim.log.levels.DEBUG when
     -- debugging issues with server installations.

--- a/lua/nvim-lsp-installer/settings.lua
+++ b/lua/nvim-lsp-installer/settings.lua
@@ -35,7 +35,6 @@ local DEFAULT_SETTINGS = {
         -- Example: { "--proxy", "https://proxyserver" }
         install_args = {},
     },
-    python3_exeutable = vim.api.nvim_get_var("python3_host_prog"),
 
     -- Controls to which degree logs are written to the log file. It's useful to set this to vim.log.levels.DEBUG when
     -- debugging issues with server installations.


### PR DESCRIPTION
Rather than hard-coding `python` or `python3`, just load the python3 that nvim knows about and let users override this setting. Since users probably already pass the checks in `:checkhealth` (ie. the python3 provider), this shouldn't be a big issue.

I'm stuck with python 2.7 on my machine (Blame Autodesk not updating their embedded python until *AFTER* python 2 was deprecated) so being able to explicitly set the executable path means I won't get stuck running Python 2 with the `python` call