### PR TITLE
fsautocomplete: don't use shell as an intermediary

### DIFF
--- a/lua/nvim-lsp-installer/servers/fsautocomplete/init.lua
+++ b/lua/nvim-lsp-installer/servers/fsautocomplete/init.lua
@@ -14,14 +14,14 @@ return function(name, root_dir)
                 { "dotnet", "dotnet was not found in path." },
             },
             ---@type ServerInstallerFunction
-            function (_, callback, ctx)
+            function(_, callback, ctx)
                 process.spawn("dotnet", {
                     args = { "tool", "update", "--tool-path", ".", "fsautocomplete" },
                     cwd = ctx.install_dir,
                     stdio_sink = ctx.stdio_sink,
-                }, function (success)
+                }, function(success)
                     if not success then
-                        ctx.stdio_sink.stderr("Failed to install fsautocomplete.\n")
+                        ctx.stdio_sink.stderr "Failed to install fsautocomplete.\n"
                         callback(false)
                     else
                         callback(true)

--- a/lua/nvim-lsp-installer/servers/fsautocomplete/init.lua
+++ b/lua/nvim-lsp-installer/servers/fsautocomplete/init.lua
@@ -11,7 +11,10 @@ return function(name, root_dir)
         homepage = "https://github.com/fsharp/FsAutoComplete",
         installer = {
             std.ensure_executables {
-                { "dotnet", "dotnet was not found in path." },
+                {
+                    "dotnet",
+                    "dotnet was not found in path. Refer to https://dotnet.microsoft.com/download for installation instructions.",
+                },
             },
             ---@type ServerInstallerFunction
             function(_, callback, ctx)

--- a/lua/nvim-lsp-installer/servers/fsautocomplete/init.lua
+++ b/lua/nvim-lsp-installer/servers/fsautocomplete/init.lua
@@ -1,7 +1,7 @@
 local server = require "nvim-lsp-installer.server"
 local path = require "nvim-lsp-installer.path"
+local process = require "nvim-lsp-installer.process"
 local std = require "nvim-lsp-installer.installers.std"
-local shell = require "nvim-lsp-installer.installers.shell"
 
 return function(name, root_dir)
     return server.Server:new {
@@ -13,7 +13,21 @@ return function(name, root_dir)
             std.ensure_executables {
                 { "dotnet", "dotnet was not found in path." },
             },
-            shell.polyshell [[dotnet tool update --tool-path . fsautocomplete]],
+            ---@type ServerInstallerFunction
+            function (_, callback, ctx)
+                process.spawn("dotnet", {
+                    args = { "tool", "update", "--tool-path", ".", "fsautocomplete" },
+                    cwd = ctx.install_dir,
+                    stdio_sink = ctx.stdio_sink,
+                }, function (success)
+                    if not success then
+                        ctx.stdio_sink.stderr("Failed to install fsautocomplete.\n")
+                        callback(false)
+                    else
+                        callback(true)
+                    end
+                end)
+            end,
         },
         default_options = {
             cmd = {


### PR DESCRIPTION
This fixes issues on Windows (and prob more platforms) where
the shell command may fail but this is not captured by the
installer.