### PR TITLE
Update lemminx to 0.18.1-451 to resolve crash with maven files

### DIFF
--- a/lua/nvim-lsp-installer/servers/lemminx/init.lua
+++ b/lua/nvim-lsp-installer/servers/lemminx/init.lua
@@ -31,7 +31,7 @@ return function(name, root_dir)
                 end
             end,
             context.set(function(ctx)
-                ctx.requested_server_version = coalesce(ctx.requested_server_version, "0.18.0-400")
+                ctx.requested_server_version = coalesce(ctx.requested_server_version, "0.18.1-451")
             end),
             context.capture(function(ctx)
                 return std.unzip_remote(

--- a/lua/nvim-lsp-installer/servers/lemminx/init.lua
+++ b/lua/nvim-lsp-installer/servers/lemminx/init.lua
@@ -31,11 +31,11 @@ return function(name, root_dir)
                 end
             end,
             context.set(function(ctx)
-                ctx.requested_server_version = coalesce(ctx.requested_server_version, "0.18.1-451")
+                ctx.requested_server_version = coalesce(ctx.requested_server_version, "LATEST")
             end),
             context.capture(function(ctx)
                 return std.unzip_remote(
-                    ("https://download.jboss.org/jbosstools/vscode/stable/lemminx-binary/%s/%s.zip"):format(
+                    ("https://download.jboss.org/jbosstools/vscode/snapshots/lemminx-binary/%s/%s.zip"):format(
                         ctx.requested_server_version,
                         unzipped_file
                     )

--- a/lua/nvim-lsp-installer/ui/state.lua
+++ b/lua/nvim-lsp-installer/ui/state.lua
@@ -14,13 +14,11 @@ function M.create_state_container(initial_state, subscriber)
         if not has_unsubscribed then
             subscriber(state)
         end
-    end,
-        function()
-            return state
-        end,
-        function(val)
-            has_unsubscribed = val
-        end
+    end, function()
+        return state
+    end, function(val)
+        has_unsubscribed = val
+    end
 end
 
 return M


### PR DESCRIPTION
lemminx crashed when I tried to open a pom.xml with version 0.18.0-400, updating to 0.18.1-451 resolved the issue. I had this issue on Fedora 35, just for info. 