### PR TITLE
added explicit expand-archive command

### DIFF
--- a/lua/nvim-lsp-installer/installers/std.lua
+++ b/lua/nvim-lsp-installer/installers/std.lua
@@ -47,7 +47,9 @@ function M.unzip(file, dest)
                     stdio_sink = context.stdio_sink,
                 }, callback)
             end,
-            win = shell.powershell(("Microsoft.PowerShell.Archive\\Expand-Archive -Path %q -DestinationPath %q"):format(file, dest)),
+            win = shell.powershell(
+                ("Microsoft.PowerShell.Archive\\Expand-Archive -Path %q -DestinationPath %q"):format(file, dest)
+            ),
         },
         installers.always_succeed(M.rmrf(file)),
     }

--- a/lua/nvim-lsp-installer/installers/std.lua
+++ b/lua/nvim-lsp-installer/installers/std.lua
@@ -47,7 +47,7 @@ function M.unzip(file, dest)
                     stdio_sink = context.stdio_sink,
                 }, callback)
             end,
-            win = shell.powershell(("Expand-Archive -Path %q -DestinationPath %q"):format(file, dest)),
+            win = shell.powershell(("Microsoft.PowerShell.Archive\\Expand-Archive -Path %q -DestinationPath %q"):format(file, dest)),
         },
         installers.always_succeed(M.rmrf(file)),
     }


### PR DESCRIPTION
There's two packages that provide the `Expand-Archive`, (see https://github.com/PowerShell/Microsoft.PowerShell.Archive/issues/52). It can happen that the wrong `Expand-Archive` is chosen, resulting in an error. This fixes that.