### PR TITLE
fix(bicep): download the langserver via the vscode distribution

### DIFF
--- a/lua/nvim-lsp-installer/installers/std.lua
+++ b/lua/nvim-lsp-installer/installers/std.lua
@@ -35,7 +35,7 @@ function M.download_file(url, out_file)
 end
 
 ---@param file string @The relative path to the file to unzip.
----@param dest string|nil @The destination of the unzip (defaults to ".").
+---@param dest string|nil @The destination of the unzip.
 function M.unzip(file, dest)
     return installers.pipe {
         installers.when {
@@ -55,6 +55,7 @@ end
 
 ---@see unzip().
 ---@param url string @The url of the .zip file.
+---@param dest string|nil @The url of the .zip file. Defaults to ".".
 function M.unzip_remote(url, dest)
     return installers.pipe {
         M.download_file(url, "archive.zip"),

--- a/lua/nvim-lsp-installer/servers/bicep/init.lua
+++ b/lua/nvim-lsp-installer/servers/bicep/init.lua
@@ -13,9 +13,16 @@ return function(name, root_dir)
             std.ensure_executables {
                 { "dotnet", "dotnet is required to run the bicep language server." },
             },
-            context.use_github_release_file("Azure/bicep", "bicep-langserver.zip"),
+            -- The bicep-langserver.zip is a bit broken on POSIX systems - so we download it via the VSCode distribution
+            -- instead. See https://github.com/Azure/bicep/issues/3704.
+            context.use_github_release_file("Azure/bicep", "vscode-bicep.vsix"),
             context.capture(function(ctx)
-                return std.unzip_remote(ctx.github_release_file)
+                return std.unzip_remote(ctx.github_release_file, "vscode")
+            end),
+            std.rename(path.concat { "vscode", "extension", "bicepLanguageServer" }, "langserver"),
+            std.rmrf "vscode",
+            context.set(function(ctx)
+                ctx.install_dir = path.concat { ctx.install_dir, "langserver" }
             end),
         },
         default_options = {


### PR DESCRIPTION
This is done to avoid issues with unzipping the bicep-langserver.zip
on POSIX systems (see https://github.com/Azure/bicep/issues/3704).

Fixes #285.