### PR TITLE
fix(powershell_es): don't limit to windows

### DIFF
--- a/lua/nvim-lsp-installer/servers/powershell_es/init.lua
+++ b/lua/nvim-lsp-installer/servers/powershell_es/init.lua
@@ -2,7 +2,6 @@ local server = require "nvim-lsp-installer.server"
 local path = require "nvim-lsp-installer.path"
 local std = require "nvim-lsp-installer.installers.std"
 local context = require "nvim-lsp-installer.installers.context"
-local installers = require "nvim-lsp-installer.installers"
 
 return function(name, root_dir)
     return server.Server:new {
@@ -10,13 +9,17 @@ return function(name, root_dir)
         root_dir = root_dir,
         homepage = "https://github.com/PowerShell/PowerShellEditorServices",
         languages = { "powershell" },
-        installer = installers.when {
-            win = {
-                context.use_github_release_file("PowerShell/PowerShellEditorServices", "PowerShellEditorServices.zip"),
-                context.capture(function(ctx)
-                    return std.unzip_remote(ctx.github_release_file)
-                end),
+        installer = {
+            std.ensure_executables {
+                {
+                    "pwsh",
+                    "pwsh was not found in path. Refer to https://github.com/PowerShell/PowerShell#get-powershell for instructions.",
+                },
             },
+            context.use_github_release_file("PowerShell/PowerShellEditorServices", "PowerShellEditorServices.zip"),
+            context.capture(function(ctx)
+                return std.unzip_remote(ctx.github_release_file)
+            end),
         },
         default_options = {
             bundle_path = path.concat { root_dir },


### PR DESCRIPTION
The [`PowerShellEditorServices`](https://github.com/PowerShell/PowerShellEditorServices) are cross-platform. This allows installing on more than just Windows.

Currently using this on Apple silicon.