### PR TITLE
fix(angularls): fix --ngProbeLocation

### DIFF
--- a/lua/nvim-lsp-installer/servers/angularls/init.lua
+++ b/lua/nvim-lsp-installer/servers/angularls/init.lua
@@ -19,7 +19,13 @@ return function(name, root_dir)
             "--tsProbeLocations",
             table.concat(append_node_modules { root_dir, workspace_dir }, ","),
             "--ngProbeLocations",
-            table.concat(append_node_modules { root_dir, workspace_dir }, ","),
+            table.concat(
+                append_node_modules {
+                    path.concat { root_dir, "node_modules", "@angular", "language-server" },
+                    workspace_dir,
+                },
+                ","
+            ),
         }
     end
 


### PR DESCRIPTION
This seems to have broken in 18fa978dde6277617c269b726532eada9119988a, due to no more dependency deduplication.