### PR TITLE
fix: zls-0.2 uses a different archive path

### DIFF
--- a/lua/nvim-lsp-installer/servers/zls/init.lua
+++ b/lua/nvim-lsp-installer/servers/zls/init.lua
@@ -27,7 +27,7 @@ return function(name, root_dir)
             context.capture(function(ctx)
                 return std.untarxz_remote(ctx.github_release_file)
             end),
-            std.rename(archive_name, "package"),
+            std.rename("bin", "package"),
         },
         default_options = {
             cmd = { path.concat { root_dir, "package", "zls" } },


### PR DESCRIPTION
See #329 for bug report: zls-0.2 change the archive format.

I'm new to the codebase so I'm not sure if this is the best way to implement the fix, but it's tested as working locally for me. Happy to make quick changes or close in favour of a different fix!