### PR TITLE
fix(health): ignore the patch number in capturing go version

### DIFF
--- a/lua/nvim-lsp-installer/health/init.lua
+++ b/lua/nvim-lsp-installer/health/init.lua
@@ -106,7 +106,7 @@ function M.check()
             name = "Go",
             check = function(version)
                 -- Parses output such as "go version go1.17.3 darwin/arm64" into major, minor, patch components
-                local _, _, major, minor = version:find "go(%d+)%.(%d+)%.(%d+)"
+                local _, _, major, minor = version:find "go(%d+)%.(%d+)"
                 -- Due to https://go.dev/doc/go-get-install-deprecation
                 if not (tonumber(major) >= 1 and tonumber(minor) >= 17) then
                     return "Go version must be >= 1.17."


### PR DESCRIPTION
### Reason
The pattern `go(%d+)%.(%d+)%.(%d+)` can **only** be matched when the `go version` contains the patch number (e.g. go1.17.3).
In my case, the go version I installed is exactly `1.17`.
![image](https://user-images.githubusercontent.com/12182069/146634108-271ecf1a-6b12-4480-8b09-9057b7e12f4c.png)


Before:
![image](https://user-images.githubusercontent.com/12182069/146633847-633d1066-080c-4e68-ac12-d41f81d2a106.png)

After:
![image](https://user-images.githubusercontent.com/12182069/146633828-55727a2c-837f-4950-a933-f855eab5724d.png)

Test result for the `go version` with/without patch number
```lua
string.find("go version go1.17 darwin/amd64", "go(%d+)%.(%d+)")
-- 12      17      1       17

string.find("go version go1.17.3 darwin/amd64", "go(%d+)%.(%d+)")
-- 12      17      1       17
```