### PR TITLE
Fixing fs.rmrf and std.git_clone

### DIFF
--- a/lua/nvim-lsp-installer/fs.lua
+++ b/lua/nvim-lsp-installer/fs.lua
@@ -21,9 +21,11 @@ end
 function M.rmrf(path)
     log.debug("fs: rmrf", path)
     assert_ownership(path)
-    if vim.fn.delete(path, "rf") ~= 0 then
-        log.debug "fs: rmrf failed"
-        error(("rmrf: Could not remove directory %q."):format(path))
+    if vim.fn.exists(path) then
+        if vim.fn.delete(path, "rf") ~= 0 then
+            log.debug "fs: rmrf failed"
+            error(("rmrf: Could not remove directory %q."):format(path))
+        end
     end
 end
 

--- a/lua/nvim-lsp-installer/installers/std.lua
+++ b/lua/nvim-lsp-installer/installers/std.lua
@@ -239,7 +239,7 @@ function M.git_clone(repo_url, opts)
         opts = vim.tbl_deep_extend("force", {
             directory = ".",
             recursive = false,
-        }, opts)
+        }, opts or {})
 
         local c = process.chain {
             cwd = context.install_dir,


### PR DESCRIPTION
Referring to issue #357 

Now fs.rmrf doesn't flood the log file with fake errors.
std.git_clone accepts opts (the second argument) as optional without giving errors