### PR TITLE
fix(zls): add chmod +x to binary

### DIFF
--- a/lua/nvim-lsp-installer/servers/zls/init.lua
+++ b/lua/nvim-lsp-installer/servers/zls/init.lua
@@ -31,6 +31,7 @@ return function(name, root_dir)
                 return std.untarxz_remote(ctx.github_release_file)
             end),
             std.rename("bin", "package"),
+            std.chmod("+x", { path.concat { "package", "zls" } }),
         },
         default_options = {
             cmd = { path.concat { root_dir, "package", "zls" } },


### PR DESCRIPTION
The executable flag seems to have disappeared in 0.9.0.