### PR TITLE
ui: map keybind to update all outdated servers

### DIFF
--- a/lua/nvim-lsp-installer/jobs/outdated-servers/init.lua
+++ b/lua/nvim-lsp-installer/jobs/outdated-servers/init.lua
@@ -76,6 +76,9 @@ function M.identify_outdated_servers(servers, on_result)
                     log.fmt_trace("No receipt found for server=%s", server.name)
                 end
             end)
+        else
+            completed_checks = completed_checks + 1
+            on_result(VersionCheckResult.fail(server), { completed = completed_checks, total = total_checks })
         end
     end
 end


### PR DESCRIPTION
Previously it'd always update all installed servers. With this change it'll
only update servers that are outdated (defaults to all installed servers if
no servers are marked as outdated when triggered).