### PR TITLE
fix(go): correct installer for versions of go > 1.11

### DIFF
--- a/lua/nvim-lsp-installer/installers/go.lua
+++ b/lua/nvim-lsp-installer/installers/go.lua
@@ -32,7 +32,7 @@ function M.packages(packages)
                 pkgs[1] = ("%s@%s"):format(pkgs[1], ctx.requested_server_version)
             end
 
-            c.run("go", vim.list_extend({ "get", "-v" }, pkgs))
+            c.run("go", vim.list_extend({ "install", "-v" }, pkgs))
             c.run("go", { "clean", "-modcache" })
 
             c.spawn(callback)

--- a/lua/nvim-lsp-installer/servers/gopls/init.lua
+++ b/lua/nvim-lsp-installer/servers/gopls/init.lua
@@ -7,7 +7,7 @@ return function(name, root_dir)
         root_dir = root_dir,
         homepage = "https://pkg.go.dev/golang.org/x/tools/gopls",
         languages = { "go" },
-        installer = go.packages { "golang.org/x/tools/gopls" },
+        installer = go.packages { "golang.org/x/tools/gopls@latest" },
         default_options = {
             cmd_env = go.env(root_dir),
         },


### PR DESCRIPTION
depending on level of support this may need to go further to see what version of Go the user has installed but this was able to finally install `gopls` on my local machine.