### PR TITLE
Change go installer from get to install

### DIFF
--- a/CUSTOM_SERVERS.md
+++ b/CUSTOM_SERVERS.md
@@ -24,7 +24,7 @@ available installers that are available out of the box.
 
 -   ### Go
 
-    #### `go.packages(packages: table)`
+    #### `go.package(package: string)`
 
     Returns an installer that installs the provided list of `packages`.
 

--- a/CUSTOM_SERVERS.md
+++ b/CUSTOM_SERVERS.md
@@ -33,7 +33,7 @@ available installers that are available out of the box.
     ```lua
     local go = require "nvim-lsp-installer.installers.go"
 
-    local installer = go.packages { "golang.org/x/tools/gopls@latest" }
+    local installer = go.package "golang.org/x/tools/gopls@latest"
     ```
 
 -   ### npm

--- a/lua/nvim-lsp-installer/installers/go.lua
+++ b/lua/nvim-lsp-installer/installers/go.lua
@@ -4,7 +4,7 @@ local process = require "nvim-lsp-installer.process"
 
 local M = {}
 
----@param package string @The Go package to install. The first item in this list will be the recipient of the server version, should the user request a specific one.
+---@param package string The Go package to install.
 function M.package(package)
     return installers.pipe {
         std.ensure_executables { { "go", "go was not found in path, refer to https://golang.org/doc/install." } },

--- a/lua/nvim-lsp-installer/installers/go.lua
+++ b/lua/nvim-lsp-installer/installers/go.lua
@@ -22,16 +22,8 @@ function M.package(package)
 
             ctx.receipt:with_primary_source(ctx.receipt.go(package))
 
-            local pkg, version = unpack(vim.split(package, "@"))
-
-            if ctx.requested_server_version then
-                -- The "head" package is the recipient for the requested version. It's.. by design... don't ask.
-                pkg = ("%s@%s"):format(pkg, ctx.requested_server_version)
-              elseif version ~= nil then
-                pkg = package
-              else
-                pkg = ("%s@latest"):format(pkg)
-            end
+            local version = ctx.requested_server_version or "latest"
+            local pkg = ("%s@%s"):format(package, version)
 
             c.run("go", { "install", "-v", pkg })
 

--- a/lua/nvim-lsp-installer/installers/go.lua
+++ b/lua/nvim-lsp-installer/installers/go.lua
@@ -32,7 +32,7 @@ function M.packages(packages)
                 pkgs[1] = ("%s@%s"):format(pkgs[1], ctx.requested_server_version)
             end
 
-            c.run("go", vim.list_extend({ "get", "-v" }, pkgs))
+            c.run("go", vim.list_extend({ "install", "-v" }, pkgs))
             c.run("go", { "clean", "-modcache" })
 
             c.spawn(callback)

--- a/lua/nvim-lsp-installer/installers/go.lua
+++ b/lua/nvim-lsp-installer/installers/go.lua
@@ -34,7 +34,6 @@ function M.package(package)
             end
 
             c.run("go", { "install", "-v", pkg })
-            c.run("go", { "clean", "-modcache" })
 
             c.spawn(callback)
         end,

--- a/lua/nvim-lsp-installer/installers/go.lua
+++ b/lua/nvim-lsp-installer/installers/go.lua
@@ -1,17 +1,15 @@
 local std = require "nvim-lsp-installer.installers.std"
 local installers = require "nvim-lsp-installer.installers"
-local Data = require "nvim-lsp-installer.data"
 local process = require "nvim-lsp-installer.process"
 
 local M = {}
 
----@param packages string[] @The Go packages to install. The first item in this list will be the recipient of the server version, should the user request a specific one.
-function M.packages(packages)
+---@param package string @The Go package to install. The first item in this list will be the recipient of the server version, should the user request a specific one.
+function M.package(package)
     return installers.pipe {
         std.ensure_executables { { "go", "go was not found in path, refer to https://golang.org/doc/install." } },
         ---@type ServerInstallerFunction
         function(_, callback, ctx)
-            local pkgs = Data.list_copy(packages or {})
             local c = process.chain {
                 env = process.graft_env {
                     GO111MODULE = "on",
@@ -22,17 +20,20 @@ function M.packages(packages)
                 stdio_sink = ctx.stdio_sink,
             }
 
-            ctx.receipt:with_primary_source(ctx.receipt.go(pkgs[1]))
-            for i = 2, #pkgs do
-                ctx.receipt:with_secondary_source(ctx.receipt.go(pkgs[i]))
-            end
+            ctx.receipt:with_primary_source(ctx.receipt.go(package))
+
+            local pkg, version = unpack(vim.split(package, "@"))
 
             if ctx.requested_server_version then
                 -- The "head" package is the recipient for the requested version. It's.. by design... don't ask.
-                pkgs[1] = ("%s@%s"):format(pkgs[1], ctx.requested_server_version)
+                pkg = ("%s@%s"):format(pkg, ctx.requested_server_version)
+              elseif version ~= nil then
+                pkg = package
+              else
+                pkg = ("%s@latest"):format(pkg)
             end
 
-            c.run("go", vim.list_extend({ "install", "-v" }, pkgs))
+            c.run("go", { "install", "-v", pkg })
             c.run("go", { "clean", "-modcache" })
 
             c.spawn(callback)

--- a/lua/nvim-lsp-installer/servers/arduino_language_server/init.lua
+++ b/lua/nvim-lsp-installer/servers/arduino_language_server/init.lua
@@ -63,7 +63,7 @@ return function(name, root_dir)
 
     local arduino_language_server_installer = installers.branch_context {
         context.set_working_dir "arduino-language-server",
-        go.packages { "github.com/arduino/arduino-language-server@latest" },
+        go.package "github.com/arduino/arduino-language-server",
     }
 
     local clangd_installer = installers.branch_context {

--- a/lua/nvim-lsp-installer/servers/arduino_language_server/init.lua
+++ b/lua/nvim-lsp-installer/servers/arduino_language_server/init.lua
@@ -63,7 +63,7 @@ return function(name, root_dir)
 
     local arduino_language_server_installer = installers.branch_context {
         context.set_working_dir "arduino-language-server",
-        go.packages { "github.com/arduino/arduino-language-server" },
+        go.packages { "github.com/arduino/arduino-language-server@latest" },
     }
 
     local clangd_installer = installers.branch_context {

--- a/lua/nvim-lsp-installer/servers/efm/init.lua
+++ b/lua/nvim-lsp-installer/servers/efm/init.lua
@@ -7,7 +7,7 @@ return function(name, root_dir)
         root_dir = root_dir,
         homepage = "https://github.com/mattn/efm-langserver",
         languages = {},
-        installer = go.packages { "github.com/mattn/efm-langserver@latest" },
+        installer = go.package "github.com/mattn/efm-langserver",
         default_options = {
             cmd_env = go.env(root_dir),
         },

--- a/lua/nvim-lsp-installer/servers/efm/init.lua
+++ b/lua/nvim-lsp-installer/servers/efm/init.lua
@@ -7,7 +7,7 @@ return function(name, root_dir)
         root_dir = root_dir,
         homepage = "https://github.com/mattn/efm-langserver",
         languages = {},
-        installer = go.packages { "github.com/mattn/efm-langserver" },
+        installer = go.packages { "github.com/mattn/efm-langserver@latest" },
         default_options = {
             cmd_env = go.env(root_dir),
         },

--- a/lua/nvim-lsp-installer/servers/gopls/init.lua
+++ b/lua/nvim-lsp-installer/servers/gopls/init.lua
@@ -7,7 +7,7 @@ return function(name, root_dir)
         root_dir = root_dir,
         homepage = "https://pkg.go.dev/golang.org/x/tools/gopls",
         languages = { "go" },
-        installer = go.packages { "golang.org/x/tools/gopls" },
+        installer = go.packages { "golang.org/x/tools/gopls@latest" },
         default_options = {
             cmd_env = go.env(root_dir),
         },

--- a/lua/nvim-lsp-installer/servers/gopls/init.lua
+++ b/lua/nvim-lsp-installer/servers/gopls/init.lua
@@ -7,7 +7,7 @@ return function(name, root_dir)
         root_dir = root_dir,
         homepage = "https://pkg.go.dev/golang.org/x/tools/gopls",
         languages = { "go" },
-        installer = go.packages { "golang.org/x/tools/gopls@latest" },
+        installer = go.package "golang.org/x/tools/gopls",
         default_options = {
             cmd_env = go.env(root_dir),
         },

--- a/lua/nvim-lsp-installer/servers/jsonnet_ls/init.lua
+++ b/lua/nvim-lsp-installer/servers/jsonnet_ls/init.lua
@@ -7,7 +7,7 @@ return function(name, root_dir)
         name = name,
         root_dir = root_dir,
         homepage = "https://github.com/jdbaldry/jsonnet-language-server",
-        installer = go.packages { "github.com/jdbaldry/jsonnet-language-server" },
+        installer = go.packages { "github.com/jdbaldry/jsonnet-language-server@latest" },
         default_options = {
             -- TODO: use env instead of cmd once https://github.com/neovim/nvim-lspconfig/pull/1559 is merged
             cmd = { path.concat { root_dir, "jsonnet-language-server" } },

--- a/lua/nvim-lsp-installer/servers/jsonnet_ls/init.lua
+++ b/lua/nvim-lsp-installer/servers/jsonnet_ls/init.lua
@@ -7,7 +7,7 @@ return function(name, root_dir)
         name = name,
         root_dir = root_dir,
         homepage = "https://github.com/jdbaldry/jsonnet-language-server",
-        installer = go.packages { "github.com/jdbaldry/jsonnet-language-server@latest" },
+        installer = go.package "github.com/jdbaldry/jsonnet-language-server",
         default_options = {
             -- TODO: use env instead of cmd once https://github.com/neovim/nvim-lspconfig/pull/1559 is merged
             cmd = { path.concat { root_dir, "jsonnet-language-server" } },

--- a/lua/nvim-lsp-installer/servers/sqls/init.lua
+++ b/lua/nvim-lsp-installer/servers/sqls/init.lua
@@ -7,7 +7,7 @@ return function(name, root_dir)
         root_dir = root_dir,
         languages = { "sql" },
         homepage = "https://github.com/lighttiger2505/sqls",
-        installer = go.packages { "github.com/lighttiger2505/sqls" },
+        installer = go.packages { "github.com/lighttiger2505/sqls@latest" },
         default_options = {
             cmd_env = go.env(root_dir),
         },

--- a/lua/nvim-lsp-installer/servers/sqls/init.lua
+++ b/lua/nvim-lsp-installer/servers/sqls/init.lua
@@ -7,7 +7,7 @@ return function(name, root_dir)
         root_dir = root_dir,
         languages = { "sql" },
         homepage = "https://github.com/lighttiger2505/sqls",
-        installer = go.packages { "github.com/lighttiger2505/sqls@latest" },
+        installer = go.package "github.com/lighttiger2505/sqls",
         default_options = {
             cmd_env = go.env(root_dir),
         },


### PR DESCRIPTION
This will update require go version 1.16 or newer. It uses `go install` instead of `go get` to install go packages.

Clarification from [go 1.16 release notes](https://tip.golang.org/doc/go1.16#modules):

> go install now accepts arguments with version suffixes (for example, go install example.com/cmd@v1.0.0). This causes go install to build and install packages in module-aware mode, ignoring the go.mod file in the current directory or any parent directory, if there is one. This is useful for installing executables without affecting the dependencies of the main module.

> go install, with or without a version suffix (as described above), is now the recommended way to build and install packages in module mode. go get should be used with the -d flag to adjust the current module's dependencies without building packages, and use of go get to build and install packages is deprecated. In a future release, the -d flag will always be enabled. 

So `go install` was introduced in 1.11 but it doesn't really work. In version 1.16 `go get` was deprecated and you are supposed to use `go install` instead. This means that this plugin will require version 1.16 or newer of go to work.

Related to: #229 