### PR TITLE
add omnisharp net6.0 support instead of mono

### DIFF
--- a/lua/nvim-lsp-installer/servers/omnisharp/init.lua
+++ b/lua/nvim-lsp-installer/servers/omnisharp/init.lua
@@ -14,6 +14,12 @@ return function(name, root_dir)
         homepage = "https://github.com/OmniSharp/omnisharp-roslyn",
         languages = { "c#" },
         installer = {
+            std.ensure_executables {
+                {
+                    "dotnet",
+                    "dotnet was not found in path. Refer to https://dotnet.microsoft.com/download for installation instructions.",
+                },
+            },
             context.use_github_release_file(
                 "OmniSharp/omnisharp-roslyn",
                 coalesce(

--- a/lua/nvim-lsp-installer/servers/omnisharp/init.lua
+++ b/lua/nvim-lsp-installer/servers/omnisharp/init.lua
@@ -4,7 +4,6 @@ local path = require "nvim-lsp-installer.path"
 local Data = require "nvim-lsp-installer.data"
 local std = require "nvim-lsp-installer.installers.std"
 local context = require "nvim-lsp-installer.installers.context"
-local dotnet = require "nvim-lsp-installer.installers.dotnet"
 
 local coalesce, when = Data.coalesce, Data.when
 

--- a/lua/nvim-lsp-installer/servers/omnisharp/init.lua
+++ b/lua/nvim-lsp-installer/servers/omnisharp/init.lua
@@ -51,7 +51,7 @@ return function(name, root_dir)
         default_options = {
             cmd = {
                 "dotnet",
-                path.concat { root_dir, "OmniSharp.dll" },
+                path.concat { root_dir, "omnisharp", "OmniSharp.dll" },
                 "--languageserver",
                 "--hostPID",
                 tostring(vim.fn.getpid()),

--- a/lua/nvim-lsp-installer/servers/omnisharp/init.lua
+++ b/lua/nvim-lsp-installer/servers/omnisharp/init.lua
@@ -17,19 +17,24 @@ return function(name, root_dir)
             context.use_github_release_file(
                 "OmniSharp/omnisharp-roslyn",
                 coalesce(
-                    when(platform.is_mac, "omnisharp-osx.zip"),
+                    when(platform.is_mac,
+                        coalesce(
+                          when(platform.arch == "x64", "omnisharp-osx-x64-net6.0.zip"),
+                          when(platform.arch == "arm64", "omnisharp-osx-arm64-net6.0.zip")
+                        )
+                    ),
                     when(
                         platform.is_linux,
                         coalesce(
-                            when(platform.arch == "x64", "omnisharp-linux-x64.zip"),
-                            when(platform.arch == "arm64", "omnisharp-linux-arm64.zip")
+                            when(platform.arch == "x64", "omnisharp-linux-x64-net6.0.zip"),
+                            when(platform.arch == "arm64", "omnisharp-linux-arm64-net6.0.zip")
                         )
                     ),
                     when(
                         platform.is_win,
                         coalesce(
-                            when(platform.arch == "x64", "omnisharp-win-x64.zip"),
-                            when(platform.arch == "arm64", "omnisharp-win-arm64.zip")
+                            when(platform.arch == "x64", "omnisharp-win-x64-net6.0.zip"),
+                            when(platform.arch == "arm64", "omnisharp-win-arm64-net6.0.zip")
                         )
                     )
                 )
@@ -37,18 +42,14 @@ return function(name, root_dir)
             context.capture(function(ctx)
                 return std.unzip_remote(ctx.github_release_file, "omnisharp")
             end),
-            std.chmod("+x", { "omnisharp/run" }),
             context.receipt(function(receipt, ctx)
                 receipt:with_primary_source(receipt.github_release_file(ctx))
             end),
         },
         default_options = {
             cmd = {
-                platform.is_win and path.concat { root_dir, "omnisharp", "OmniSharp.exe" } or path.concat {
-                    root_dir,
-                    "omnisharp",
-                    "run",
-                },
+                "dotnet",
+                path.concat { root_dir, "OmniSharp.dll" },
                 "--languageserver",
                 "--hostPID",
                 tostring(vim.fn.getpid()),

--- a/lua/nvim-lsp-installer/servers/omnisharp/init.lua
+++ b/lua/nvim-lsp-installer/servers/omnisharp/init.lua
@@ -4,6 +4,7 @@ local path = require "nvim-lsp-installer.path"
 local Data = require "nvim-lsp-installer.data"
 local std = require "nvim-lsp-installer.installers.std"
 local context = require "nvim-lsp-installer.installers.context"
+local dotnet = require "nvim-lsp-installer.installers.dotnet"
 
 local coalesce, when = Data.coalesce, Data.when
 
@@ -17,10 +18,11 @@ return function(name, root_dir)
             context.use_github_release_file(
                 "OmniSharp/omnisharp-roslyn",
                 coalesce(
-                    when(platform.is_mac,
+                    when(
+                        platform.is_mac,
                         coalesce(
-                          when(platform.arch == "x64", "omnisharp-osx-x64-net6.0.zip"),
-                          when(platform.arch == "arm64", "omnisharp-osx-arm64-net6.0.zip")
+                            when(platform.arch == "x64", "omnisharp-osx-x64-net6.0.zip"),
+                            when(platform.arch == "arm64", "omnisharp-osx-arm64-net6.0.zip")
                         )
                     ),
                     when(


### PR DESCRIPTION
This PR will add support for omnisharp language srever that runs on .NET6.0 instead of mono, the support for .NET6.0 omnisharp came out in the release `1.38.0` and will replace the mono version as mentioned in this PR `https://github.com/OmniSharp/omnisharp-roslyn/pull/2291#issuecomment-985834029`
