### PR TITLE
remove npm install --production from ansiblels

### DIFF
--- a/lua/nvim-lsp-installer/servers/ansiblels/init.lua
+++ b/lua/nvim-lsp-installer/servers/ansiblels/init.lua
@@ -15,7 +15,6 @@ return function(name, root_dir)
             npm.install { "npm@latest" }, -- ansiblels has quite a strict npm version requirement
             npm.exec("npm", { "install" }),
             npm.run "compile",
-            npm.exec("npm", { "install", "--production" }),
             context.receipt(function(receipt)
                 receipt:with_primary_source(receipt.git_remote "https://github.com/ansible/ansible-language-server")
             end),


### PR DESCRIPTION
Latest ansible-language-server fails on install with this line present.
the combination of `npm install` and `npm run compile` should be enough since `npm install` gets both the production and dev dependencies.  

`npm install --production` fails with missing typescript type definitions missing. 
```
 node_modules/@nodelib/fs.scandir/out/providers/async.d.ts(1,23): error TS2688: Cannot find type definition file for 'node'.
 node_modules/@nodelib/fs.scandir/out/providers/async.d.ts(4,45): error TS2503: Cannot find namespace 'NodeJS'.
 node_modules/@nodelib/fs.scandir/out/types/index.d.ts(1,23): error TS2688: Cannot find type definition file for 'node'.
```
