### PR TITLE
Support libc detection

### DIFF
--- a/lua/nvim-lsp-installer/installers/context.lua
+++ b/lua/nvim-lsp-installer/installers/context.lua
@@ -84,8 +84,8 @@ function M.use_github_release_file(repo, file, opts)
                     )
                     context.stdio_sink.stderr(
                         (
-                            "Could not find which release file to download. Most likely, the current operating system or architecture (%s) is not supported.\n"
-                        ):format(platform.arch)
+                            "Could not find which release file to download. Most likely the current operating system, architecture (%s), or libc (%s) is not supported.\n"
+                        ):format(platform.arch, platform.get_libc())
                     )
                     return nil
                 end

--- a/lua/nvim-lsp-installer/platform.lua
+++ b/lua/nvim-lsp-installer/platform.lua
@@ -27,14 +27,12 @@ M.is_linux = not M.is_mac and M.is_unix
 
 -- @return string @The libc found on the system, musl or glibc (glibc if ldd is not found)
 function M.get_libc()
-    local libc
     local _, _, libc_exit_code = os.execute("ldd --version 2>&1 | grep -q musl")
     if (libc_exit_code == 0) then
-        libc = "musl"
+        return "musl"
     else
-        libc = "glibc"
+        return "glibc"
     end
-    return libc
 end
 
 -- PATH separator

--- a/lua/nvim-lsp-installer/platform.lua
+++ b/lua/nvim-lsp-installer/platform.lua
@@ -28,7 +28,7 @@ M.is_linux = not M.is_mac and M.is_unix
 M.libc = "glibc"
 
 if (M.is_linux) then
-    local found_musl = os.execute("ldd --version | grep -q musl")
+    local found_musl = os.execute("ldd --version 2>&1 | grep -q musl")
     if (found_musl) then
         M.libc = "musl"
     end

--- a/lua/nvim-lsp-installer/platform.lua
+++ b/lua/nvim-lsp-installer/platform.lua
@@ -1,7 +1,6 @@
 local M = {}
 
 local uname = vim.loop.os_uname()
-local Data = require "nvim-lsp-installer.data"
 
 ---@alias Platform
 ---| '"win"'
@@ -26,17 +25,15 @@ M.is_unix = vim.fn.has "unix" == 1
 M.is_mac = vim.fn.has "mac" == 1
 M.is_linux = not M.is_mac and M.is_unix
 
-M.get_libc = Data.memoize(
-    -- @return string @The libc found on the system, musl or glibc (glibc if ldd is not found)
-    function()
-        local _, _, libc_exit_code = os.execute "ldd --version 2>&1 | grep -q musl"
-        if libc_exit_code == 0 then
-            return "musl"
-        else
-            return "glibc"
-        end
+-- @return string @The libc found on the system, musl or glibc (glibc if ldd is not found)
+function M.get_libc()
+    local _, _, libc_exit_code = os.execute("ldd --version 2>&1 | grep -q musl")
+    if (libc_exit_code == 0) then
+        return "musl"
+    else
+        return "glibc"
     end
-)
+end
 
 -- PATH separator
 M.path_sep = M.is_win and ";" or ":"

--- a/lua/nvim-lsp-installer/platform.lua
+++ b/lua/nvim-lsp-installer/platform.lua
@@ -1,3 +1,4 @@
+
 local M = {}
 
 local uname = vim.loop.os_uname()
@@ -24,6 +25,14 @@ M.is_win = vim.fn.has "win32" == 1
 M.is_unix = vim.fn.has "unix" == 1
 M.is_mac = vim.fn.has "mac" == 1
 M.is_linux = not M.is_mac and M.is_unix
+M.libc = "glibc"
+
+if (M.is_linux) then
+    local found_musl = os.execute("ldd --version | grep -q musl")
+    if (found_musl) then
+        M.libc = "musl"
+    end
+end
 
 -- PATH separator
 M.path_sep = M.is_win and ";" or ":"

--- a/lua/nvim-lsp-installer/platform.lua
+++ b/lua/nvim-lsp-installer/platform.lua
@@ -27,8 +27,8 @@ M.is_linux = not M.is_mac and M.is_unix
 
 -- @return string @The libc found on the system, musl or glibc (glibc if ldd is not found)
 function M.get_libc()
-    local _, _, libc_exit_code = os.execute("ldd --version 2>&1 | grep -q musl")
-    if (libc_exit_code == 0) then
+    local _, _, libc_exit_code = os.execute "ldd --version 2>&1 | grep -q musl"
+    if libc_exit_code == 0 then
         return "musl"
     else
         return "glibc"

--- a/lua/nvim-lsp-installer/platform.lua
+++ b/lua/nvim-lsp-installer/platform.lua
@@ -1,4 +1,3 @@
-
 local M = {}
 
 local uname = vim.loop.os_uname()

--- a/lua/nvim-lsp-installer/platform.lua
+++ b/lua/nvim-lsp-installer/platform.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local uname = vim.loop.os_uname()
+local Data = require "nvim-lsp-installer.data"
 
 ---@alias Platform
 ---| '"win"'
@@ -25,15 +26,17 @@ M.is_unix = vim.fn.has "unix" == 1
 M.is_mac = vim.fn.has "mac" == 1
 M.is_linux = not M.is_mac and M.is_unix
 
--- @return string @The libc found on the system, musl or glibc (glibc if ldd is not found)
-function M.get_libc()
-    local _, _, libc_exit_code = os.execute("ldd --version 2>&1 | grep -q musl")
-    if (libc_exit_code == 0) then
-        return "musl"
-    else
-        return "glibc"
+M.get_libc = Data.memoize(
+    -- @return string @The libc found on the system, musl or glibc (glibc if ldd is not found)
+    function()
+        local _, _, libc_exit_code = os.execute "ldd --version 2>&1 | grep -q musl"
+        if libc_exit_code == 0 then
+            return "musl"
+        else
+            return "glibc"
+        end
     end
-end
+)
 
 -- PATH separator
 M.path_sep = M.is_win and ";" or ":"

--- a/lua/nvim-lsp-installer/platform.lua
+++ b/lua/nvim-lsp-installer/platform.lua
@@ -25,13 +25,17 @@ M.is_win = vim.fn.has "win32" == 1
 M.is_unix = vim.fn.has "unix" == 1
 M.is_mac = vim.fn.has "mac" == 1
 M.is_linux = not M.is_mac and M.is_unix
-M.libc = "glibc"
 
-if (M.is_linux) then
-    local found_musl = os.execute("ldd --version 2>&1 | grep -q musl")
-    if (found_musl) then
-        M.libc = "musl"
+-- @return string @The libc found on the system, musl or glibc (glibc if ldd is not found)
+function M.get_libc()
+    local libc
+    local _, _, libc_exit_code = os.execute("ldd --version 2>&1 | grep -q musl")
+    if (libc_exit_code == 0) then
+        libc = "musl"
+    else
+        libc = "glibc"
     end
+    return libc
 end
 
 -- PATH separator

--- a/lua/nvim-lsp-installer/servers/rust_analyzer/init.lua
+++ b/lua/nvim-lsp-installer/servers/rust_analyzer/init.lua
@@ -7,6 +7,8 @@ local Data = require "nvim-lsp-installer.data"
 
 local coalesce, when = Data.coalesce, Data.when
 
+local libc = platform.get_libc()
+
 local target = coalesce(
     when(
         platform.is_mac,
@@ -19,14 +21,14 @@ local target = coalesce(
         platform.is_linux,
         coalesce(
             when(
-                platform.libc == "glibc",
+                platform.get_libc() == "glibc",
                 coalesce(
                     when(platform.arch == "arm64", "rust-analyzer-aarch64-unknown-linux-gnu.gz"),
                     when(platform.arch == "x64", "rust-analyzer-x86_64-unknown-linux-gnu.gz")
                 )
             ),
             when(
-                platform.libc == "musl",
+                platform.get_libc() == "musl",
                 coalesce(when(platform.arch == "x64", "rust-analyzer-x86_64-unknown-linux-musl.gz"))
             )
         )

--- a/lua/nvim-lsp-installer/servers/rust_analyzer/init.lua
+++ b/lua/nvim-lsp-installer/servers/rust_analyzer/init.lua
@@ -27,7 +27,7 @@ local target = coalesce(
             ),
             when(
                 platform.libc == "musl",
-                coalesce(when(platform.arch == "x64", "rust-analyzer-x86_64-unknown-linux-musl"))
+                coalesce(when(platform.arch == "x64", "rust-analyzer-x86_64-unknown-linux-musl.gz"))
             )
         )
     ),

--- a/lua/nvim-lsp-installer/servers/rust_analyzer/init.lua
+++ b/lua/nvim-lsp-installer/servers/rust_analyzer/init.lua
@@ -27,10 +27,7 @@ local target = coalesce(
                     when(platform.arch == "x64", "rust-analyzer-x86_64-unknown-linux-gnu.gz")
                 )
             ),
-            when(
-                libc == "musl",
-                coalesce(when(platform.arch == "x64", "rust-analyzer-x86_64-unknown-linux-musl.gz"))
-            )
+            when(libc == "musl", coalesce(when(platform.arch == "x64", "rust-analyzer-x86_64-unknown-linux-musl.gz")))
         )
     ),
     when(

--- a/lua/nvim-lsp-installer/servers/rust_analyzer/init.lua
+++ b/lua/nvim-lsp-installer/servers/rust_analyzer/init.lua
@@ -21,14 +21,14 @@ local target = coalesce(
         platform.is_linux,
         coalesce(
             when(
-                platform.get_libc() == "glibc",
+                libc == "glibc",
                 coalesce(
                     when(platform.arch == "arm64", "rust-analyzer-aarch64-unknown-linux-gnu.gz"),
                     when(platform.arch == "x64", "rust-analyzer-x86_64-unknown-linux-gnu.gz")
                 )
             ),
             when(
-                platform.get_libc() == "musl",
+                libc == "musl",
                 coalesce(when(platform.arch == "x64", "rust-analyzer-x86_64-unknown-linux-musl.gz"))
             )
         )

--- a/lua/nvim-lsp-installer/servers/rust_analyzer/init.lua
+++ b/lua/nvim-lsp-installer/servers/rust_analyzer/init.lua
@@ -18,8 +18,17 @@ local target = coalesce(
     when(
         platform.is_linux,
         coalesce(
-            when(platform.arch == "arm64", "rust-analyzer-aarch64-unknown-linux-gnu.gz"),
-            when(platform.arch == "x64", "rust-analyzer-x86_64-unknown-linux-gnu.gz")
+            when(
+                platform.libc == "glibc",
+                coalesce(
+                    when(platform.arch == "arm64", "rust-analyzer-aarch64-unknown-linux-gnu.gz"),
+                    when(platform.arch == "x64", "rust-analyzer-x86_64-unknown-linux-gnu.gz")
+                )
+            ),
+            when(
+                platform.libc == "musl",
+                coalesce(when(platform.arch == "x64", "rust-analyzer-x86_64-unknown-linux-musl"))
+            )
         )
     ),
     when(


### PR DESCRIPTION
Resolves #514. `libc` lookup is now deferred into a function. Only major issue is that it relies on `ldd` which is not guaranteed to be installed, for instance on MacOS, but this is likely not an issue that will crop up as this is pointed more towards Linux with distributions that use `musl` instead of `glibc`.