### PR TITLE
Fix r_language_server installation

### DIFF
--- a/lua/nvim-lsp-installer/servers/r_language_server/init.lua
+++ b/lua/nvim-lsp-installer/servers/r_language_server/init.lua
@@ -8,7 +8,8 @@ return function(name, root_dir)
 options(langserver_library = %q);
 options(repos = list(CRAN = "http://cran.rstudio.com/"));
 rlsLib <- getOption("langserver_library");
-install.packages("languageserversetup", lib = rlsLib);
+install.packages("remotes", lib = rlsLib);
+remotes::install_github("jozefhajnala/languageserversetup", lib = rlsLib)
 loadNamespace("languageserversetup", lib.loc = rlsLib);
 
 languageserversetup::languageserver_install(


### PR DESCRIPTION
Use latest languageserversetup (0.1.2.900) from GitHub instead of that hosted
on CRAN. 0.1.2.900 uses remotes::install_github instead of install-github.me.

See https://github.com/jozefhajnala/languageserversetup/pull/5