### PR TITLE
Keep user library paths when starting R language server

### DIFF
--- a/lua/nvim-lsp-installer/servers/r_language_server/init.lua
+++ b/lua/nvim-lsp-installer/servers/r_language_server/init.lua
@@ -37,7 +37,7 @@ library("languageserver", lib.loc = rlsLib);
     local server_script = ([[
 options("langserver_library" = %q);
 rlsLib <- getOption("langserver_library");
-.libPaths(new = rlsLib);
+.libPaths(new = c(rlsLib, .libPaths()));
 loadNamespace("languageserver", lib.loc = rlsLib);
 languageserver::run();
   ]]):format(root_dir)


### PR DESCRIPTION
### Pull Request Overview

- Fixes 609

In this PR, the `server.R` has been modified to prepend the R language server location, keeping the user library in the search path. This will make the lsp auto-completion works for all R libraries installed.