### PR TITLE
fix(terraformls): use `root-dir` instead of `root-dir/terraform-ls` as cmd path

### DIFF
--- a/lua/nvim-lsp-installer/servers/terraformls/init.lua
+++ b/lua/nvim-lsp-installer/servers/terraformls/init.lua
@@ -1,6 +1,5 @@
 local server = require "nvim-lsp-installer.server"
 local process = require "nvim-lsp-installer.process"
-local path = require "nvim-lsp-installer.path"
 local platform = require "nvim-lsp-installer.platform"
 local Data = require "nvim-lsp-installer.data"
 local github = require "nvim-lsp-installer.core.managers.github"
@@ -45,7 +44,7 @@ return function(name, root_dir)
         end,
         default_options = {
             cmd_env = {
-                PATH = process.extend_path { path.concat { root_dir, "terraform-ls" } },
+                PATH = process.extend_path { root_dir },
             },
         },
     }


### PR DESCRIPTION
The terraform-ls installation contains no subdirectories, the binary gets extracted to the `root-dir` directory.