### PR TITLE
feat(middleware): add 'ignore_in_path' feature to ignore unnecessary automatic installations

### DIFF
--- a/lua/nvim-lsp-installer/middleware.lua
+++ b/lua/nvim-lsp-installer/middleware.lua
@@ -1,3 +1,4 @@
+local lspconfig = require "lspconfig"
 local util = require "lspconfig.util"
 local servers = require "nvim-lsp-installer.servers"
 local settings = require "nvim-lsp-installer.settings"
@@ -28,7 +29,11 @@ function M.register_lspconfig_hook()
             if server:is_installed() then
                 merge_in_place(config, server._default_options)
             end
-            if settings.current.automatic_installation and not server:is_installed() then
+            if
+                settings.current.automatic_installation
+                and not server:is_installed()
+                and (not settings.current.ignore_in_path or vim.fn.executable(lspconfig[server.name].cmd[1]))
+            then
                 server:install()
             end
         end

--- a/lua/nvim-lsp-installer/settings.lua
+++ b/lua/nvim-lsp-installer/settings.lua
@@ -8,6 +8,8 @@ local DEFAULT_SETTINGS = {
     ensure_installed = {},
     -- Whether servers that are set up (via lspconfig) should be automatically installed if they're not already installed.
     automatic_installation = false,
+    -- Whether to ignore automatic installation if the server command is found in the system path
+    ignore_in_path = false,
     ui = {
         icons = {
             -- The list icon to use for installed servers.


### PR DESCRIPTION
This adds the ability to ignore automatic installations if an language server command is already available on the user's PATH. I currently have it in place to only be regarding the automatic installer. If the user manually installs an LSP then it should still install as they are specifically choosing to install it.