### PR TITLE
update hls asset file name for version >= 1.7

### DIFF
--- a/lua/nvim-lsp-installer/servers/hls/init.lua
+++ b/lua/nvim-lsp-installer/servers/hls/init.lua
@@ -19,6 +19,7 @@ return function(name, root_dir)
                 repo = "haskell/haskell-language-server",
                 asset_file = function(version)
                     local target = coalesce(
+                        when(version >= "1.7", "haskell-language-server-%s-src.tar.gz"),
                         when(platform.is_mac, "haskell-language-server-macOS-%s.tar.gz"),
                         when(platform.is_linux, "haskell-language-server-Linux-%s.tar.gz"),
                         when(platform.is_win, "haskell-language-server-Windows-%s.tar.gz")


### PR DESCRIPTION
With v1.7.0.0 the asset file names changed for the haskell language server (https://github.com/haskell/haskell-language-server/releases/tag/1.7.0.0). With this change `:LspInstall hls` works again.