### PR TITLE
fix!(beancount-language-server):update beancount install source

### DIFF
--- a/lua/nvim-lsp-installer/servers/beancount/init.lua
+++ b/lua/nvim-lsp-installer/servers/beancount/init.lua
@@ -16,15 +16,9 @@ return function(name, root_dir)
         homepage = "https://github.com/polarmutex/beancount-language-server",
         async = true,
         ---@param ctx InstallContext
-        installer = function(ctx)
-            cargo.install("beancount-language-server").with_receipt()
-            pip3.install { "beancount" }
-            ctx.receipt:with_secondary_source(ctx.receipt.pip3 "beancount")
-        end,
+        installer = cargo.crate("beancount-language-server"),
         default_options = {
-            cmd_env = {
-                PATH = process.extend_path { path.concat { root_dir, "bin" }, pip3.venv_path(root_dir) },
-            },
+            cmd_env = cargo.env(root_dir)
         },
     }
 end

--- a/lua/nvim-lsp-installer/servers/beancount/init.lua
+++ b/lua/nvim-lsp-installer/servers/beancount/init.lua
@@ -1,10 +1,6 @@
 local server = require "nvim-lsp-installer.server"
-local pip3 = require "nvim-lsp-installer.core.managers.pip3"
 local Data = require "nvim-lsp-installer.data"
-local platform = require "nvim-lsp-installer.platform"
 local cargo = require "nvim-lsp-installer.core.managers.cargo"
-local path = require "nvim-lsp-installer.path"
-local process = require "nvim-lsp-installer.process"
 
 local coalesce, when = Data.coalesce, Data.when
 
@@ -15,7 +11,6 @@ return function(name, root_dir)
         languages = { "beancount" },
         homepage = "https://github.com/polarmutex/beancount-language-server",
         async = true,
-        ---@param ctx InstallContext
         installer = cargo.crate("beancount-language-server"),
         default_options = {
             cmd_env = cargo.env(root_dir)

--- a/lua/nvim-lsp-installer/servers/beancount/init.lua
+++ b/lua/nvim-lsp-installer/servers/beancount/init.lua
@@ -1,8 +1,5 @@
 local server = require "nvim-lsp-installer.server"
-local Data = require "nvim-lsp-installer.data"
 local cargo = require "nvim-lsp-installer.core.managers.cargo"
-
-local coalesce, when = Data.coalesce, Data.when
 
 return function(name, root_dir)
     return server.Server:new {
@@ -11,9 +8,9 @@ return function(name, root_dir)
         languages = { "beancount" },
         homepage = "https://github.com/polarmutex/beancount-language-server",
         async = true,
-        installer = cargo.crate("beancount-language-server"),
+        installer = cargo.crate "beancount-language-server",
         default_options = {
-            cmd_env = cargo.env(root_dir)
+            cmd_env = cargo.env(root_dir),
         },
     }
 end

--- a/lua/nvim-lsp-installer/servers/beancount/init.lua
+++ b/lua/nvim-lsp-installer/servers/beancount/init.lua
@@ -1,8 +1,9 @@
 local server = require "nvim-lsp-installer.server"
-local github = require "nvim-lsp-installer.core.managers.github"
 local pip3 = require "nvim-lsp-installer.core.managers.pip3"
 local Data = require "nvim-lsp-installer.data"
 local platform = require "nvim-lsp-installer.platform"
+local cargo = require "nvim-lsp-installer.core.managers.cargo"
+local path = require "nvim-lsp-installer.path"
 local process = require "nvim-lsp-installer.process"
 
 local coalesce, when = Data.coalesce, Data.when
@@ -16,29 +17,13 @@ return function(name, root_dir)
         async = true,
         ---@param ctx InstallContext
         installer = function(ctx)
-            local asset_file = assert(
-                coalesce(
-                    when(platform.is_mac, "beancount-language-server-macos-x64.zip"),
-                    when(platform.is_linux and platform.arch == "x64", "beancount-language-server-linux-x64.zip"),
-                    when(platform.is_win and platform.arch == "x64", "beancount-language-server-windows-x64.zip")
-                ),
-                "Unsupported platform"
-            )
-            github.unzip_release_file({
-                repo = "polarmutex/beancount-language-server",
-                asset_file = asset_file,
-            }).with_receipt()
-
-            local file_ext = platform.is_win and ".exe" or ""
-            -- We rename the binary to conform with lspconfig
-            ctx.fs:rename(("beancount-language-server%s"):format(file_ext), ("beancount-langserver%s"):format(file_ext))
-
+            cargo.install("beancount-language-server").with_receipt()
             pip3.install { "beancount" }
             ctx.receipt:with_secondary_source(ctx.receipt.pip3 "beancount")
         end,
         default_options = {
             cmd_env = {
-                PATH = process.extend_path { root_dir, pip3.venv_path(root_dir) },
+                PATH = process.extend_path { path.concat { root_dir, "bin" }, pip3.venv_path(root_dir) },
             },
         },
     }


### PR DESCRIPTION
From the latest update from beancount-lsp repo, the owner didn't offer binary asset anymore. Instead, he recommended use cargo to install the server, check here (https://github.com/polarmutex/beancount-language-server#installation)