### PR TITLE
docs: add comment to duplicate *DEPRECATED* tag

### DIFF
--- a/doc/nvim-lsp-installer.txt
+++ b/doc/nvim-lsp-installer.txt
@@ -382,7 +382,7 @@ class: Server
                     nvim-lsp-installer, and not the default options provided
                     by lspconfig.
 
-            - on_ready({handler}) *DEPRECATED*
+            - on_ready({handler}) *DEPRECATED - setup servers directly via lspconfig instead*
                     Registers the provided {handler} to be called when the
                     server is ready to be setup.
 


### PR DESCRIPTION
Hello !

As stated in [this](https://github.com/williamboman/nvim-lsp-installer/issues/658) issue, the documentation contains a duplicated *DEPRECATED* tag which prevents some systems from building the plugins correctly.

I've added a comment to one of the tags saying to configure the servers through `lsp-config` directly (as it had been done for previous deprecated functions).

Thank you for your work and your amazing plugin 😄 