### PR TITLE
Updates Fortran Language Server

### DIFF
--- a/lua/nvim-lsp-installer/servers/fortls/init.lua
+++ b/lua/nvim-lsp-installer/servers/fortls/init.lua
@@ -5,9 +5,9 @@ return function(name, root_dir)
     return server.Server:new {
         name = name,
         root_dir = root_dir,
-        homepage = "https://github.com/hansec/fortran-language-server",
+        homepage = "https://github.com/gnikit/fortls",
         languages = { "fortran" },
-        installer = pip3.packages { "fortran-language-server" },
+        installer = pip3.packages { "fortls" },
         default_options = {
             cmd_env = pip3.env(root_dir),
         },


### PR DESCRIPTION
switches to `fortls` from `fortran-language-server`.  `fortls` is a continuation of the `fortran-language-server` since it got abandoned ~2y ago. 

The name of the binary was chosen to be the same to allow VS Code, Atom and other editors to be easily backwards compatible without having to rewrite every extension. For that reason `fortls` and `fortran-language-server` cannot be simultaneously installed in a system, since the binary will be overwritten with whichever was installed last.

I also noticed that there is an autogenerated schema file: `fortls.lua` taken from the Fortran Intellisense VS Code extension that should preferably be deleted. That interface was problematic with the original `fortran-language-server` and is completly incompatible with `fortls` and the [Modern Fortran](https://github.com/fortran-lang/vscode-fortran-support) VS Code extension

Full disclosure I am the author of both fortls and Modern Fortran