### PR TITLE
fix(spawn): avoid spawning commands that aren't on PATH

### DIFF
--- a/lua/nvim-lsp-installer/core/managers/pip3/init.lua
+++ b/lua/nvim-lsp-installer/core/managers/pip3/init.lua
@@ -62,6 +62,7 @@ function M.install(packages)
                 settings.current.pip.install_args,
                 pkgs,
                 env = M.env(ctx.cwd:get()), -- use venv env
+                check_executable = false,
             }
         end)
         :or_else_throw "Unable to create python3 venv environment."
@@ -95,6 +96,7 @@ function M.check_outdated_primary_package(receipt, install_dir)
         "--format=json",
         cwd = install_dir,
         env = M.env(install_dir), -- use venv
+        check_executable = false,
     }):map_catching(function(result)
         ---@alias PipOutdatedPackage {name: string, version: string, latest_version: string}
         ---@type PipOutdatedPackage[]
@@ -131,6 +133,7 @@ function M.get_installed_primary_package_version(receipt, install_dir)
         "--format=json",
         cwd = install_dir,
         env = M.env(install_dir), -- use venv env
+        check_executable = false,
     }):map_catching(function(result)
         local pip_packages = vim.json.decode(result.stdout)
         local normalized_pip_package = M.normalize_package(receipt.primary_source.package)

--- a/tests/core/managers/pip3_spec.lua
+++ b/tests/core/managers/pip3_spec.lua
@@ -53,6 +53,7 @@ describe("pip3 manager", function()
                     "supporting-package2",
                 },
                 env = match.is_table(),
+                check_executable = false,
             })
         end)
     )
@@ -113,6 +114,7 @@ describe("pip3 manager", function()
                 match.tbl_containing { "--proxy", "http://localhost:8080" },
                 match.tbl_containing { "package" },
                 env = match.is_table(),
+                check_executable = false,
             })
         end)
     )
@@ -170,6 +172,7 @@ describe("pip3 version check", function()
                 "--format=json",
                 cwd = "/tmp/install/dir",
                 env = match.table(),
+                check_executable = false,
             })
             assert.is_true(result:is_success())
             assert.equals("1.3.0", result:get_or_nil())
@@ -208,6 +211,7 @@ describe("pip3 version check", function()
                 "--format=json",
                 cwd = "/tmp/install/dir",
                 env = match.table(),
+                check_executable = false,
             })
             assert.is_true(result:is_success())
             assert.same({

--- a/tests/core/spawn_spec.lua
+++ b/tests/core/spawn_spec.lua
@@ -153,10 +153,22 @@ describe("async spawn", function()
                 callback(false, 127)
             end)
 
+            local result = spawn.bash {}
+            assert.is_true(result:is_failure())
+            assert.equals(
+                "spawn: bash failed with exit code 127. This is an error message for bash!",
+                tostring(result:err_or_nil())
+            )
+        end)
+    )
+
+    it(
+        "should skip checking executable",
+        async_test(function()
             local result = spawn.my_cmd {}
             assert.is_true(result:is_failure())
             assert.equals(
-                "spawn: my_cmd failed with exit code 127. This is an error message for my_cmd!",
+                "spawn: my_cmd failed with no exit code. my_cmd is not executable",
                 tostring(result:err_or_nil())
             )
         end)


### PR DESCRIPTION
This is primarily done to avoid cluttering the log file with a bunch of
ERROR entries. Also avoids unnecessary roundtrips to uv_spawn, I guess.