### PR TITLE
docs: remove nvim-lsp-installer.servers helptag

### DIFF
--- a/doc/nvim-lsp-installer.txt
+++ b/doc/nvim-lsp-installer.txt
@@ -332,9 +332,6 @@ info_window.open()
 info_window.close()
     Closes the `:LspInstallInfo` UI window.
 
-==============================================================================
-Lua module: nvim-lsp-installer.servers           *nvim-lsp-installer.servers*
-
                                  *nvim-lsp-installer.get_available_servers()*
 get_available_servers()
         Return: ~

--- a/lua/nvim-lsp-installer.lua
+++ b/lua/nvim-lsp-installer.lua
@@ -275,7 +275,6 @@ function M.on_server_ready(cb)
     end)
 end
 
--- old API
 M.get_server = servers.get_server
 M.get_available_servers = servers.get_available_servers
 M.get_installed_servers = servers.get_installed_servers

--- a/lua/nvim-lsp-installer/server.lua
+++ b/lua/nvim-lsp-installer/server.lua
@@ -1,5 +1,4 @@
 local dispatcher = require "nvim-lsp-installer.dispatcher"
-local notify = require "nvim-lsp-installer.notify"
 local a = require "nvim-lsp-installer.core.async"
 local InstallContext = require "nvim-lsp-installer.core.installer.context"
 local fs = require "nvim-lsp-installer.core.fs"

--- a/tests/middleware_spec.lua
+++ b/tests/middleware_spec.lua
@@ -1,5 +1,4 @@
 local util = require "lspconfig.util"
-local a = require "nvim-lsp-installer.core.async"
 local servers = require "nvim-lsp-installer.servers"
 local middleware = require "nvim-lsp-installer.middleware"
 


### PR DESCRIPTION
All interactions from userland should preferably go through
require("nvim-lsp-installer").