### PR TITLE
fix the taplo with the upstream

### DIFF
--- a/lua/nvim-lsp-installer/servers/taplo/init.lua
+++ b/lua/nvim-lsp-installer/servers/taplo/init.lua
@@ -7,7 +7,7 @@ return function(name, root_dir)
         root_dir = root_dir,
         languages = { "toml" },
         homepage = "https://taplo.tamasfe.dev/lsp/",
-        installer = cargo.crate "taplo-cli",
+        installer = cargo.crate("taplo-cli", { features = "lsp" }),
         default_options = {
             cmd_env = cargo.env(root_dir),
         },


### PR DESCRIPTION
Because the lsp is not the default feature in taplo, so need to add the feature