### PR TITLE
fix(texlab): download aarch64 assets on arm macOS

### DIFF
--- a/lua/nvim-lsp-installer/servers/texlab/init.lua
+++ b/lua/nvim-lsp-installer/servers/texlab/init.lua
@@ -19,7 +19,8 @@ return function(name, root_dir)
                     github.untargz_release_file({
                         repo = repo,
                         asset_file = coalesce(
-                            when(platform.is_mac, "texlab-x86_64-macos.tar.gz"),
+                            when(platform.is_mac and platform.arch == "arm64", "texlab-aarch64-macos.tar.gz"),
+                            when(platform.is_mac and platform.arch == "x64", "texlab-x86_64-macos.tar.gz"),
                             when(platform.is_linux and platform.arch == "x64", "texlab-x86_64-linux.tar.gz")
                         ),
                     }).with_receipt()

--- a/lua/nvim-lsp-installer/servers/texlab/init.lua
+++ b/lua/nvim-lsp-installer/servers/texlab/init.lua
@@ -19,9 +19,9 @@ return function(name, root_dir)
                     github.untargz_release_file({
                         repo = repo,
                         asset_file = coalesce(
-                            when(platform.is_mac and platform.arch == "arm64", "texlab-aarch64-macos.tar.gz"),
-                            when(platform.is_mac and platform.arch == "x64", "texlab-x86_64-macos.tar.gz"),
-                            when(platform.is_linux and platform.arch == "x64", "texlab-x86_64-linux.tar.gz")
+                            when(platform.is.mac_arm64, "texlab-aarch64-macos.tar.gz"),
+                            when(platform.is.mac_x64, "texlab-x86_64-macos.tar.gz"),
+                            when(platform.is.linux_x64, "texlab-x86_64-linux.tar.gz")
                         ),
                     }).with_receipt()
                 end,


### PR DESCRIPTION
Updated the texlab server script: in the two most recent texlab releases a pre-built aarch64 server for macOS can be downloaded.