### PR TITLE
Configs passed by lspconfig.setup{...} would be overwritten.

### DIFF
--- a/lua/nvim-lsp-installer/middleware.lua
+++ b/lua/nvim-lsp-installer/middleware.lua
@@ -16,10 +16,10 @@ local function merge_in_place(t1, t2)
         if type(v) == "table" then
             if type(t1[k]) == "table" and not vim.tbl_islist(t1[k]) then
                 merge_in_place(t1[k], v)
-            else
+            elseif not t1[k] then
                 t1[k] = v
             end
-        else
+        elseif not t1[k] then
             t1[k] = v
         end
     end

--- a/lua/nvim-lsp-installer/servers/jdtls/init.lua
+++ b/lua/nvim-lsp-installer/servers/jdtls/init.lua
@@ -102,12 +102,17 @@ return function(name, root_dir)
                 -- We redefine the cmd in on_new_config because `cmd` will be invalid if the user has not installed
                 -- jdtls when starting the session (due to vim.fn.expand returning an empty string, because it can't
                 -- locate the file).
-                config.cmd = get_cmd(
+		-- it seems that vim.fn.expand could return original patterns when expanding fails, tested in linux and mac.
+		-- only replace config.cmd when org.eclipse.equinox.launcher_*.jar expanding fails.
+		cmd = unpack(config.cmd)
+		if string.find(cmd, "-jar  -") or string.find(cmd, "*.jar") then
+		  config.cmd = get_cmd(
                     vim.env.WORKSPACE and vim.env.WORKSPACE or path.concat { vim.env.HOME, "workspace" },
                     workspace_path,
                     config.vmargs or DEFAULT_VMARGS,
                     config.use_lombok_agent or false
-                )
+                 )
+	        end
             end,
         },
     }


### PR DESCRIPTION
FIX1: configs passed by require'lspconfig'.xxxx.setup{...} would be overwritten by the on_setup
FIX2: jdtls on_new_config hook functions could overwrite the config.cmd passed by setup{}.