### PR TITLE
fix(gunzip): win_extract

### DIFF
--- a/lua/nvim-lsp-installer/core/managers/std/init.lua
+++ b/lua/nvim-lsp-installer/core/managers/std/init.lua
@@ -150,14 +150,14 @@ end
 ---@async
 ---@param file string
 function M.gunzip(file)
+    local function gunzip()
+        local ctx = installer.context()
+        ctx.spawn.gzip { "-d", file }
+    end
+    
     platform.when {
-        unix = function()
-            local ctx = installer.context()
-            ctx.spawn.gzip { "-d", file }
-        end,
-        win = function()
-            win_extract(file)
-        end,
+        unix = gunzip,
+        win = gunzip
     }
 end
 


### PR DESCRIPTION
extracted the unix 'gunzip' function into a local function named 'gunzip'
assigned the 'gunzip' to the platform unix and win

win_extract is obsolete in windows >= 10.

fixes #827 