### PR TITLE
docs: use single quotes for vim-plug installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ use {
 ### vim-plug
 
 ```vim
-Plug "williamboman/nvim-lsp-installer"
-Plug "neovim/nvim-lspconfig"
+Plug 'williamboman/nvim-lsp-installer'
+Plug 'neovim/nvim-lspconfig'
 ```
 
 ## Usage


### PR DESCRIPTION
As noted [here](https://github.com/junegunn/vim-plug/issues/1074#issuecomment-791891919), `vim-plug` does not support double quotes for package names.

Since this is a silent failure i.e. it simply won't install the package, copying and pasting from the README almost made me pull my hair out :sweat_smile: 